### PR TITLE
Add paginated playlist navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,14 +81,31 @@
     .tt { background: #000000; }
 
     /* Siatka kafelków */
+    .playlist-window {
+      max-width: 1200px;
+      margin: 18px auto 40px;
+      padding: 0 16px;
+      position: relative;
+      overflow: hidden;
+    }
     #playlist {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
       gap: 18px;
-      max-width: 1200px;
-      margin: 18px auto 40px;
-      padding: 0 16px;
     }
+    .nav-btn {
+      position: absolute;
+      left: 50%;
+      transform: translateX(-50%);
+      background: rgba(0,0,0,0.6);
+      border: none;
+      color: #fff;
+      padding: 8px 12px;
+      cursor: pointer;
+      font-size: 1.2em;
+    }
+    .nav-btn.up { top: 0; }
+    .nav-btn.down { bottom: 0; }
     .video-tile {
       background: #1e1e1e;
       border-radius: 12px;
@@ -167,7 +184,11 @@
     </div>
   </div>
 
-  <div id="playlist"></div>
+  <div id="playlist-window" class="playlist-window" tabindex="0">
+    <button id="btnPrev" class="nav-btn up" aria-label="Pokaż wcześniejsze filmy">&#9650;</button>
+    <div id="playlist"></div>
+    <button id="btnNext" class="nav-btn down" aria-label="Pokaż kolejne filmy">&#9660;</button>
+  </div>
 
   <footer>
     © ExploRide • Urbex, filmy i mapa miejsc, których prawie nie ma
@@ -178,6 +199,10 @@
     // --- USTAWIENIA ---
     const API_KEY     = "AIzaSyAWgh8sgcGfnEc26JAe5EA-1gNyJw9XZlA";
     const PLAYLIST_ID = "PL8VD37UX-sp0Ei-uxx4UEuXtP_5m-5oFn";
+    const PAGE_SIZE   = 4;
+    let allVideos = [];
+    let currentIndex = 0;
+    let btnPrev, btnNext;
 
     // Tryb awaryjny: PODMIEŃ TE ID NA SWOJE STARSZE FILMY (nie najnowszy)
     const STATIC_FALLBACK_VIDEO_IDS = [
@@ -224,6 +249,18 @@
       }).join("");
     }
 
+    function updateNav() {
+      if (!btnPrev || !btnNext) return;
+      btnPrev.style.display = currentIndex > 0 ? "block" : "none";
+      btnNext.style.display = currentIndex + PAGE_SIZE < allVideos.length ? "block" : "none";
+    }
+
+    function renderPage() {
+      const slice = allVideos.slice(currentIndex, currentIndex + PAGE_SIZE);
+      renderTiles(slice);
+      updateNav();
+    }
+
     async function fetchAllPlaylistItems(playlistId) {
       const base = "https://www.googleapis.com/youtube/v3/playlistItems";
       let pageToken = "";
@@ -257,18 +294,38 @@
     }
 
     function renderStaticFallback() {
-      const list = STATIC_FALLBACK_VIDEO_IDS.map(id => ({
+      allVideos = STATIC_FALLBACK_VIDEO_IDS.map(id => ({
         id,
         title: "ExploRide – wideo",
         date: "", // można wpisać ręcznie daty, jeśli chcesz
         thumb: `https://i.ytimg.com/vi/${id}/hqdefault.jpg`
       }));
-      renderTiles(list);
+      currentIndex = 0;
+      renderPage();
     }
 
     async function init() {
       const loader   = document.getElementById("loader");
       const fallback = document.getElementById("fallback");
+      btnPrev = document.getElementById("btnPrev");
+      btnNext = document.getElementById("btnNext");
+      const win = document.getElementById("playlist-window");
+
+      btnPrev.addEventListener("click", () => {
+        currentIndex = Math.max(0, currentIndex - PAGE_SIZE);
+        renderPage();
+      });
+      btnNext.addEventListener("click", () => {
+        if (currentIndex + PAGE_SIZE < allVideos.length) {
+          currentIndex += PAGE_SIZE;
+          renderPage();
+        }
+      });
+      win.addEventListener("keydown", e => {
+        if (e.key === "ArrowDown") { e.preventDefault(); btnNext.click(); }
+        if (e.key === "ArrowUp")   { e.preventDefault(); btnPrev.click(); }
+      });
+      win.focus();
 
       try {
         let list = await fetchAllPlaylistItems(PLAYLIST_ID);
@@ -283,7 +340,9 @@
         // Usuń najnowszy (pierwszy po sortowaniu)
         if (list.length > 0) list = list.slice(1);
 
-        renderTiles(list);
+        allVideos = list;
+        currentIndex = 0;
+        renderPage();
         loader.style.display = "none";
       } catch (e) {
         console.warn("Playlist API error -> tryb awaryjny", e);


### PR DESCRIPTION
## Summary
- Show playlist videos in a window that displays only four at a time
- Add up/down buttons and keyboard controls to page through videos

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c7f0c1a7e48330b434088190745bb8