### PR TITLE
Add Facebook feed section to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,9 +82,84 @@
 
     <hr class="divider" />
 
+  <!-- ======== Facebook: Najnowsze posty ======== -->
+  <h2>Najnowsze posty z Facebooka</h2>
+  <p class="lead">Kliknij kartę, aby otworzyć post na Facebooku.</p>
+
+  <div class="center">
+    <div id="fb-feed-loader" class="loader">Ładowanie postów…</div>
+    <div id="fb-feed-fallback" class="fallback" style="display:none;">
+      Nie udało się pobrać postów. Zobacz więcej na Facebooku:
+      <br />
+      <a class="btn" target="_blank" href="https://www.facebook.com/ExploRideURBEX">Otwórz Facebook</a>
+    </div>
+  </div>
+
+  <div id="fb-feed" class="fb-grid"></div>
+  <!-- ======== /Facebook: Najnowsze posty ======== -->
+
+    <hr class="divider" />
+
   <footer>
     © ExploRide • Urbex i podróże
   </footer>
+
+  <script>
+    // ---- USTAWIENIA ----
+    const WORKER_URL = "https://fb-feed.eksplorajder.workers.dev/api/fb/posts";
+    const FB_PAGE_ID = "145171925888318";   // Twoje Page ID
+    const FB_LIMIT   = 6;                   // ile postów pokazać
+
+    const esc = (s = "") => s.replaceAll("<", "&lt;");
+
+    const fmtDatePL = iso => {
+      const d = new Date(iso); if (isNaN(d)) return "";
+      return `${String(d.getDate()).padStart(2, "0")}.${String(d.getMonth() + 1).padStart(2, "0")}.${d.getFullYear()}`;
+    };
+
+    const postCard = p => {
+      const firstImg = (p.media && p.media.length) ? p.media[0].src : null;
+      return `
+        <a class="fb-card" href="${p.permalink_url}" target="_blank" rel="noopener">
+          ${firstImg ? `<div class="fb-media"><img src="${firstImg}" alt="Post ExploRide" loading="lazy"></div>` : ""}
+          <div class="fb-body">
+            <div class="fb-date">${fmtDatePL(p.created_time)}</div>
+            <div class="fb-text">${esc(p.message || "")}</div>
+          </div>
+        </a>
+      `;
+    };
+
+    async function loadFbFeed() {
+      const loader = document.getElementById("fb-feed-loader");
+      const fallback = document.getElementById("fb-feed-fallback");
+      const grid = document.getElementById("fb-feed");
+      try {
+        const url = new URL(WORKER_URL);
+        url.searchParams.set("page_id", FB_PAGE_ID);
+        url.searchParams.set("limit", String(FB_LIMIT));
+
+        const res = await fetch(url.toString(), { credentials: "omit" });
+        if (!res.ok) throw new Error("HTTP " + res.status);
+        const data = await res.json();
+        const items = data.items || [];
+        if (!items.length) throw new Error("Brak postów");
+
+        grid.innerHTML = items.map(postCard).join("");
+        loader.style.display = "none";
+      } catch (e) {
+        console.warn("FB feed error", e);
+        loader.style.display = "none";
+        fallback.style.display = "block";
+      }
+    }
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", loadFbFeed);
+    } else {
+      loadFbFeed();
+    }
+  </script>
 
   <!-- Skrypt na końcu, by statyczna treść zawsze się wyświetliła -->
   <script>

--- a/style.css
+++ b/style.css
@@ -185,5 +185,55 @@ height: auto
       border-radius: 10px; background: #e50914; color: #fff; text-decoration: none;
     }
 
+    /* Facebook feed */
+    .fb-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 16px;
+      max-width: 1200px;
+      margin: 18px auto 40px;
+      padding: 0 16px;
+    }
+    .fb-card {
+      background: #1e1e1e;
+      border: 1px solid #2a2a2a;
+      border-radius: 12px;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      text-align: left;
+      transition: transform 0.2s ease;
+    }
+    .fb-card:hover { transform: translateY(-3px); }
+    .fb-media {
+      position: relative;
+      width: 100%;
+      padding-top: 56.25%;
+      background: #000;
+      overflow: hidden;
+    }
+    .fb-media img {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+    .fb-body { padding: 12px 14px; }
+    .fb-date {
+      font-size: 0.85em;
+      color: #bbb;
+      margin-bottom: 6px;
+    }
+    .fb-text {
+      white-space: pre-wrap;
+      color: #fff;
+      font-size: 0.98em;
+      line-height: 1.35;
+      max-height: 6.5em;
+      overflow: hidden;
+    }
+
       footer { color: #bbb; font-size: 0.9em; margin: 24px 0 30px; }
     </style>


### PR DESCRIPTION
## Summary
- add a Facebook posts section at the bottom of the homepage with loader and fallback messaging
- fetch the latest posts via the Cloudflare worker and render media cards with dates and text
- style the new grid and cards to match the existing dark theme

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8aab1a9c48330bad7eac7c9cfbebd