### PR TITLE
Add Instagram feed section to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,139 @@
   <div id="fb-feed" class="fb-grid"></div>
   <!-- ======== /Facebook: Najnowsze posty ======== -->
 
-    <hr class="divider" />
+  <hr class="divider" />
+
+  <!-- ======== Instagram: Najnowsze ======== -->
+  <h2>Najnowsze z Instagrama</h2>
+  <p class="lead">Kliknij kafelek, żeby otworzyć post na Instagramie.</p>
+
+  <div class="center">
+    <div id="ig-loader" class="loader">Ładowanie postów z Instagrama…</div>
+    <div id="ig-fallback" class="fallback" style="display:none;">
+      Nie udało się pobrać postów. Zobacz nasz profil:
+      <br />
+      <a class="btn" target="_blank" href="https://www.instagram.com/exploride.urbex/">Otwórz Instagram</a>
+    </div>
+  </div>
+
+  <div id="ig-grid" class="ig-grid"></div>
+
+  <style>
+    /* Siatka i kafelki IG */
+    .ig-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 12px;
+      max-width: 1200px;
+      margin: 18px auto 40px;
+      padding: 0 16px;
+    }
+
+    .ig-tile {
+      background: #1e1e1e;
+      border: 1px solid #2a2a2a;
+      border-radius: 12px;
+      overflow: hidden;
+      display: block;
+      text-decoration: none;
+      transition: transform 0.2s ease;
+    }
+
+    .ig-tile:hover {
+      transform: translateY(-3px);
+    }
+
+    .ig-media {
+      position: relative;
+      width: 100%;
+      padding-top: 100%;
+      background: #000;
+      overflow: hidden;
+    }
+
+    .ig-media img {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+    .ig-caption {
+      padding: 10px 12px;
+      text-align: left;
+      color: #fff;
+      font-size: 0.95em;
+      max-height: 4.4em;
+      overflow: hidden;
+      white-space: pre-wrap;
+    }
+
+    .ig-date {
+      padding: 0 12px 10px;
+      color: #bbb;
+      font-size: 0.85em;
+      text-align: left;
+    }
+  </style>
+
+  <script>
+    {
+      // ---- KONFIG ----
+      const IG_API = "https://fb-feed.eksplorajder.workers.dev/api/ig/media";
+      const IG_PAGEID = "145171925888318"; // FB Page ID; worker sam znajdzie IG account
+      const IG_LIMIT = 9; // ile kafelków
+
+      const esc = (s = "") => s.replaceAll("<", "&lt;");
+      const fmt = iso => {
+        const d = new Date(iso);
+        if (isNaN(d)) return "";
+        return `${String(d.getDate()).padStart(2, "0")}.${String(d.getMonth() + 1).padStart(2, "0")}.${d.getFullYear()}`;
+      };
+
+      const card = m => `
+        <a class="ig-tile" href="${m.permalink}" target="_blank" rel="noopener">
+          <div class="ig-media">
+            <img src="${m.src}" alt="Instagram ExploRide" loading="lazy">
+          </div>
+          ${m.caption ? `<div class="ig-caption">${esc(m.caption)}</div>` : ""}
+          <div class="ig-date">${fmt(m.timestamp)}</div>
+        </a>
+      `;
+
+      async function loadIG() {
+        const loader = document.getElementById("ig-loader");
+        const fallback = document.getElementById("ig-fallback");
+        const grid = document.getElementById("ig-grid");
+        try {
+          const u = new URL(IG_API);
+          u.searchParams.set("page_id", IG_PAGEID);
+          u.searchParams.set("limit", String(IG_LIMIT));
+          const res = await fetch(u.toString(), { credentials: "omit" });
+          if (!res.ok) throw new Error("HTTP " + res.status);
+          const data = await res.json();
+          const items = data.items || [];
+          if (!items.length) throw new Error("Brak postów IG");
+          grid.innerHTML = items.map(card).join("");
+          loader.style.display = "none";
+        } catch (e) {
+          console.warn("IG feed error", e);
+          loader.style.display = "none";
+          fallback.style.display = "block";
+        }
+      }
+
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", loadIG);
+      } else {
+        loadIG();
+      }
+    }
+  </script>
+  <!-- ======== /Instagram: Najnowsze ======== -->
+
+  <hr class="divider" />
 
   <footer>
     © ExploRide • Urbex i podróże


### PR DESCRIPTION
## Summary
- add an Instagram section at the bottom of the homepage with loader, fallback and grid layout
- fetch recent Instagram posts from the worker API and render captions safely

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8b729578083309fb67aa64ed02565