### PR TITLE
Fix Instagram feed normalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,6 +189,52 @@
         return `${String(d.getDate()).padStart(2, "0")}.${String(d.getMonth() + 1).padStart(2, "0")}.${d.getFullYear()}`;
       };
 
+      const pickSrc = m => {
+        if (!m) return null;
+        if (m.src) return m.src;
+        if (m.media_type === "IMAGE") {
+          return m.media_url || null;
+        }
+        if (m.media_type === "VIDEO") {
+          return m.thumbnail_url || m.media_url || null;
+        }
+        if (m.media_type === "CAROUSEL_ALBUM") {
+          let child = null;
+          if (m.children && Array.isArray(m.children.data)) {
+            child = m.children.data.find(Boolean) || null;
+          }
+          if (child) {
+            return child.thumbnail_url || child.media_url || null;
+          }
+        }
+        return null;
+      };
+
+      const normalizeIgItems = data => {
+        const raw = Array.isArray(data && data.items)
+          ? data.items
+          : Array.isArray(data && data.data)
+            ? data.data
+            : [];
+        const mapped = raw
+          .map(item => ({
+            id: item.id,
+            caption: item.caption || "",
+            type: item.media_type,
+            src: pickSrc(item),
+            permalink: item.permalink,
+            timestamp: item.timestamp
+          }))
+          .filter(item => !!item.src);
+
+        mapped.sort((a, b) => {
+          const ta = a.timestamp ? Date.parse(a.timestamp) : 0;
+          const tb = b.timestamp ? Date.parse(b.timestamp) : 0;
+          return (tb || 0) - (ta || 0);
+        });
+        return mapped;
+      };
+
       const card = m => `
         <a class="ig-tile" href="${m.permalink}" target="_blank" rel="noopener">
           <div class="ig-media">
@@ -210,7 +256,7 @@
           const res = await fetch(u.toString(), { credentials: "omit" });
           if (!res.ok) throw new Error("HTTP " + res.status);
           const data = await res.json();
-          const items = data.items || [];
+          const items = normalizeIgItems(data);
           if (!items.length) throw new Error("Brak postów IG");
           grid.innerHTML = items.map(card).join("");
           loader.style.display = "none";


### PR DESCRIPTION
## Summary
- normalize the Instagram API response on the client before rendering
- derive usable media URLs for all media types and keep the grid sorted by timestamp

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8bd7608d883309036ed5f6699a816