### PR TITLE
Add navigation menu to scroll to homepage sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,21 @@
     </script>
   </head>
 <body>
-  <header><img src="logo.png" alt="ExploRide logo" class="logo"> <span>EXPLORIDE.PL</span></header>
+  <header>
+    <div class="brand">
+      <img src="logo.png" alt="ExploRide logo" class="logo">
+      <span class="brand-name">EXPLORIDE.PL</span>
+    </div>
+    <nav class="top-nav" aria-label="Główna nawigacja">
+      <a class="nav-link" href="#filmy">Filmy</a>
+      <a class="nav-link" href="#posty-fb">Posty na FB</a>
+      <a class="nav-link" href="#posty-ig">Posty z IG</a>
+      <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
+      <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Sklep</button>
+      <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Kontakt</button>
+      <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Materiały do pobrania</button>
+    </nav>
+  </header>
 
   <div class="social-section">
     <!-- SOCIAL -->
@@ -47,7 +61,7 @@
 
     <hr class="divider" />
 
-  <div class="player-wrap">
+  <div class="player-wrap" id="filmy">
     <h2>Najnowszy film</h2>
     <div class="ratio">
       <!-- Player playlisty (YouTube sam odtworzy najnowszy jako pierwszy) -->
@@ -83,7 +97,7 @@
     <hr class="divider" />
 
   <!-- ======== Facebook: Najnowsze posty ======== -->
-  <h2>Najnowsze posty z Facebooka</h2>
+  <h2 id="posty-fb">Najnowsze posty z Facebooka</h2>
   <p class="lead">Kliknij kartę, aby otworzyć post na Facebooku.</p>
 
   <div class="center">
@@ -101,7 +115,7 @@
   <hr class="divider" />
 
   <!-- ======== Instagram: Najnowsze ======== -->
-  <h2>Najnowsze z Instagrama</h2>
+  <h2 id="posty-ig">Najnowsze z Instagrama</h2>
   <p class="lead">Kliknij kafelek, żeby otworzyć post na Instagramie.</p>
 
   <div class="center">

--- a/style.css
+++ b/style.css
@@ -1,7 +1,11 @@
   <style>
     * { box-sizing: border-box; }
-    html, body { height: 100%; }
+    html {
+      height: 100%;
+      scroll-behavior: smooth;
+    }
     body {
+      height: 100%;
       margin: 0;
       background: #111 url('background.jpg') no-repeat center 0;
       background-size: 110% 110%;
@@ -13,16 +17,77 @@
     header {
       background: #000;
       color: #fff;
-      padding: 20px;
+      padding: 20px 16px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 18px;
+    }
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
       font-size: 2em;
       font-weight: bold;
       letter-spacing: 2px;
+      text-transform: uppercase;
+    }
+    .brand-name { display: inline-block; }
+    header .logo { height: 48px; }
+    .top-nav {
       display: flex;
-      align-items: center;
+      flex-wrap: wrap;
       justify-content: center;
       gap: 12px;
     }
-    header .logo { height: 48px; }
+    .top-nav .nav-link {
+      display: inline-flex;
+      align-items: center;
+      padding: 8px 18px;
+      border-radius: 999px;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      background: rgba(255, 255, 255, 0.08);
+      color: #fff;
+      text-decoration: none;
+      font-size: 0.95em;
+      transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .top-nav a.nav-link { text-decoration: none; }
+    .top-nav button.nav-link {
+      font: inherit;
+      background: rgba(255, 255, 255, 0.08);
+      color: inherit;
+    }
+    .top-nav .nav-link:hover,
+    .top-nav .nav-link:focus-visible {
+      background: #e50914;
+      border-color: #e50914;
+      color: #fff;
+    }
+    .top-nav .nav-link--disabled {
+      opacity: 0.55;
+      cursor: not-allowed;
+      background: rgba(255, 255, 255, 0.05);
+      border-color: rgba(255, 255, 255, 0.08);
+    }
+    .top-nav .nav-link--disabled:hover,
+    .top-nav .nav-link--disabled:focus-visible {
+      background: rgba(255, 255, 255, 0.05);
+      border-color: rgba(255, 255, 255, 0.08);
+      color: #fff;
+    }
+    @media (min-width: 768px) {
+      header {
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .top-nav {
+        justify-content: flex-end;
+      }
+    }
     h2 {
       margin: 28px auto 12px;
       font-size: 1.8em;


### PR DESCRIPTION
## Summary
- add a header navigation that scrolls to the film, Facebook, and Instagram sections on the landing page
- include placeholder buttons for future areas like the blog, shop, contact, and downloads
- update the global styles with smooth scrolling and responsive navigation styling

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68c90a9c6b5483309609f42686e68832