### PR TITLE
Add downloads page with logo preview and navigation updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,20 +19,20 @@
       });
     </script>
   </head>
-<body>
+<body class="page-home">
   <header>
-    <div class="brand">
+    <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
       <span class="brand-name">EXPLORIDE.PL</span>
-    </div>
+    </a>
     <nav class="top-nav" aria-label="Główna nawigacja">
-      <a class="nav-link" href="#filmy">Filmy</a>
+      <a class="nav-link nav-link--home" href="#filmy" aria-current="page">Filmy</a>
       <a class="nav-link" href="#posty-fb">Posty na FB</a>
       <a class="nav-link" href="#posty-ig">Posty z IG</a>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Sklep</button>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Kontakt</button>
-      <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Materiały do pobrania</button>
+      <a class="nav-link nav-link--downloads" href="materialy.html">Materiały do pobrania</a>
     </nav>
   </header>
 

--- a/materialy.html
+++ b/materialy.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Materiały do pobrania – ExploRide</title>
+  <link rel="icon" type="image/png" href="logo.png" />
+  <link rel="stylesheet" href="style.css">
+  <script>
+    document.addEventListener('scroll', () => {
+      const y = window.scrollY * 0.2;
+      document.body.style.backgroundPosition = `center ${-y}px`;
+    });
+  </script>
+</head>
+<body class="page-downloads">
+  <header>
+    <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
+      <img src="logo.png" alt="ExploRide logo" class="logo">
+      <span class="brand-name">EXPLORIDE.PL</span>
+    </a>
+    <nav class="top-nav" aria-label="Główna nawigacja">
+      <a class="nav-link nav-link--home" href="index.html#filmy">Filmy</a>
+      <a class="nav-link" href="index.html#posty-fb">Posty na FB</a>
+      <a class="nav-link" href="index.html#posty-ig">Posty z IG</a>
+      <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
+      <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Sklep</button>
+      <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Kontakt</button>
+      <a class="nav-link nav-link--downloads" href="materialy.html" aria-current="page">Materiały do pobrania</a>
+    </nav>
+  </header>
+
+  <main class="downloads-main">
+    <h1>Materiały do pobrania</h1>
+    <p class="lead">Pobierz oficjalne logo ExploRide, aby wykorzystać je w grafikach, artykułach lub materiałach promocyjnych.</p>
+
+    <section class="download-card">
+      <object class="download-preview" data="logo.pdf#toolbar=0&navpanes=0&scrollbar=0" type="application/pdf" aria-label="Podgląd logo ExploRide">
+        <p>Twoja przeglądarka nie obsługuje podglądu PDF. <a href="logo.pdf">Pobierz logo</a>.</p>
+      </object>
+
+      <div class="download-info">
+        <h2>Logo ExploRide</h2>
+        <p class="download-description">Plik w formacie PDF zawiera logo ExploRide w wysokiej jakości, gotowe do druku i publikacji online.</p>
+        <div class="download-actions">
+          <a class="download-btn" href="logo.pdf" download>
+            <svg viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M5 20h14v-2H5v2zm7-18-7 7h4v6h6v-6h4l-7-7z"/></svg>
+            Pobierz logo (PDF)
+          </a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    &copy; <span id="year"></span> ExploRide. Wszystkie prawa zastrzeżone.
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -31,7 +31,12 @@
       font-weight: bold;
       letter-spacing: 2px;
       text-transform: uppercase;
+      color: #fff;
+      text-decoration: none;
+      transition: color 0.2s ease;
     }
+    .brand:hover,
+    .brand:focus-visible { color: #e50914; }
     .brand-name { display: inline-block; }
     header .logo { height: 48px; }
     .top-nav {
@@ -65,6 +70,12 @@
       background: #e50914;
       border-color: #e50914;
       color: #fff;
+    }
+    .top-nav .nav-link[aria-current="page"] {
+      background: #e50914;
+      border-color: #e50914;
+      color: #fff;
+      cursor: default;
     }
     .top-nav .nav-link--disabled {
       opacity: 0.55;
@@ -204,7 +215,7 @@
       border: 1px solid #2a2a2a;
       width: 240px;
       flex: 0 0 240px;
-height: auto
+      height: auto;
     }
     .video-tile:hover { transform: translateY(-3px); }
     .thumb {
@@ -298,6 +309,103 @@ height: auto
       line-height: 1.35;
       max-height: 6.5em;
       overflow: hidden;
+    }
+
+    /* Materiały do pobrania */
+    .downloads-main {
+      max-width: 960px;
+      margin: 36px auto 80px;
+      padding: 0 16px;
+    }
+    .downloads-main h1 {
+      margin: 0 0 12px;
+      font-size: 2.2em;
+      color: #fff;
+    }
+    .downloads-main .lead {
+      margin-bottom: 28px;
+    }
+    .download-card {
+      background: rgba(17, 17, 17, 0.85);
+      border: 1px solid #2a2a2a;
+      border-radius: 18px;
+      padding: 24px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 24px;
+      box-shadow: 0 0 20px rgba(0, 0, 0, 0.3);
+    }
+    .download-preview {
+      width: 240px;
+      height: 240px;
+      max-width: 100%;
+      border-radius: 14px;
+      border: 1px solid #2a2a2a;
+      background: #fff;
+      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+    }
+    .download-preview p {
+      margin: 0;
+      padding: 12px;
+      font-size: 0.9em;
+      color: #222;
+    }
+    .download-info {
+      max-width: 420px;
+      text-align: left;
+    }
+    .download-info h2 {
+      margin: 0 0 12px;
+      font-size: 1.6em;
+      color: #e50914;
+    }
+    .download-description {
+      margin: 0;
+      color: #ddd;
+      line-height: 1.5;
+    }
+    .download-actions {
+      margin-top: 18px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      justify-content: center;
+    }
+    .download-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 12px 26px;
+      border-radius: 999px;
+      background: #e50914;
+      color: #fff;
+      text-decoration: none;
+      font-weight: bold;
+      box-shadow: 0 10px 24px rgba(229, 9, 20, 0.35);
+      transition: background 0.2s ease, transform 0.2s ease;
+    }
+    .download-btn:hover,
+    .download-btn:focus-visible {
+      background: #b20710;
+      transform: translateY(-1px);
+    }
+    .download-btn svg {
+      width: 1.1em;
+      height: 1.1em;
+    }
+    @media (min-width: 768px) {
+      .download-card {
+        flex-direction: row;
+        align-items: center;
+        justify-content: center;
+      }
+      .download-info {
+        text-align: left;
+      }
+      .download-actions {
+        justify-content: flex-start;
+      }
     }
 
       footer { color: #bbb; font-size: 0.9em; margin: 24px 0 30px; }


### PR DESCRIPTION
## Summary
- make the header logo/name clickable and replace the disabled downloads button with a real navigation link that can highlight the active page
- add a dedicated "Materiały do pobrania" page with an embedded logo preview and download button
- extend the shared stylesheet with active navigation styling and layout for the downloads content

## Testing
- not run (static site changes only)


------
https://chatgpt.com/codex/tasks/task_e_68c90e2bcb3083309566a574bd739927