### PR TITLE
Disable homepage auto-scroll and update navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,8 @@
       <span class="brand-name">EXPLORIDE.PL</span>
     </a>
     <nav class="top-nav" aria-label="Główna nawigacja">
-      <a class="nav-link nav-link--home" href="#filmy" aria-current="page">Filmy</a>
+      <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">O nas</button>
+      <a class="nav-link nav-link--home" href="#filmy">Filmy</a>
       <a class="nav-link" href="#posty-fb">Posty na FB</a>
       <a class="nav-link" href="#posty-ig">Posty z IG</a>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
@@ -444,7 +445,6 @@
         if (e.key === "ArrowLeft")  { e.preventDefault(); btnPrev.click(); }
       });
       playlist.addEventListener("scroll", updateNav);
-      win.focus();
 
       try {
         let list = await fetchAllPlaylistItems(PLAYLIST_ID);

--- a/materialy.html
+++ b/materialy.html
@@ -20,6 +20,7 @@
       <span class="brand-name">EXPLORIDE.PL</span>
     </a>
     <nav class="top-nav" aria-label="Główna nawigacja">
+      <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">O nas</button>
       <a class="nav-link nav-link--home" href="index.html#filmy">Filmy</a>
       <a class="nav-link" href="index.html#posty-fb">Posty na FB</a>
       <a class="nav-link" href="index.html#posty-ig">Posty z IG</a>


### PR DESCRIPTION
## Summary
- add a placeholder "O nas" navigation button ahead of the existing links
- stop highlighting homepage navigation by removing the default aria-current flag
- prevent the playlist section from stealing focus and scrolling the page on load

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c912c7c5f88330a2e37d1c07bc4953