### PR TITLE
Add custom fonts support

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,4 +1,18 @@
   <style>
+    @font-face {
+      font-family: 'Base02';
+      src: url('fonts/Base 02.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+      font-display: swap;
+    }
+    @font-face {
+      font-family: 'BebasNeue';
+      src: url('fonts/BebasNeue-Regular.woff2') format('woff2');
+      font-weight: 400;
+      font-style: normal;
+      font-display: swap;
+    }
     * { box-sizing: border-box; }
     html {
       height: 100%;
@@ -10,9 +24,20 @@
       background: #111 url('background.jpg') no-repeat center 0;
       background-size: 110% 110%;
       color: #fff;
-      font-family: Arial, Helvetica, sans-serif;
+      font-family: 'Base02', Arial, Helvetica, sans-serif;
       text-align: center;
       overflow-x: hidden;
+    }
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      font-family: 'BebasNeue', 'Base02', Arial, Helvetica, sans-serif;
+    }
+    p {
+      font-family: 'Base02', Arial, Helvetica, sans-serif;
     }
     header {
       background: #000;
@@ -37,13 +62,18 @@
     }
     .brand:hover,
     .brand:focus-visible { color: #e50914; }
-    .brand-name { display: inline-block; }
+    .brand-name {
+      display: inline-block;
+      font-family: 'Base02', Arial, Helvetica, sans-serif;
+    }
     header .logo { height: 48px; }
     .top-nav {
       display: flex;
       flex-wrap: wrap;
       justify-content: center;
       gap: 12px;
+      font-family: 'BebasNeue', 'Base02', Arial, Helvetica, sans-serif;
+      font-size: 0.95em;
     }
     .top-nav .nav-link {
       display: inline-flex;


### PR DESCRIPTION
## Summary
- add `@font-face` declarations for the Base02 and BebasNeue webfonts with swap display
- apply Base02 to body text elements and the ExploRide brand label
- style headings and navigation controls with BebasNeue to demonstrate the new typefaces

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c91cad2ed48330aeb648aeb3165842