### PR TITLE
Adjust social media buttons for mobile layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -164,18 +164,26 @@
     }
 
     /* Social */
-    .buttons { margin: 18px 0 22px; }
+    .buttons {
+      margin: 18px 0 22px;
+      display: flex;
+      justify-content: center;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
     .buttons a {
       display: inline-flex;
       align-items: center;
+      justify-content: center;
       gap: 8px;
-      margin: 8px;
       padding: 12px 24px;
       color: #fff;
       text-decoration: none;
       font-size: 1.05em;
       border-radius: 10px;
       transition: background 0.25s, transform 0.2s;
+      text-align: center;
+      line-height: 1.2;
     }
     .buttons a:hover { transform: translateY(-1px); }
     .buttons svg { width: 1.2em; height: 1.2em; }
@@ -183,6 +191,33 @@
     .fb { background: #1877f2; }
     .ig { background: #e1306c; }
     .tt { background: #2b8543; }
+
+    @media (max-width: 768px) {
+      .buttons a {
+        font-size: clamp(0.7rem, 0.6rem + 0.8vw, 0.95rem);
+        padding: clamp(8px, 1.4vw + 4px, 12px) clamp(12px, 2vw + 6px, 20px);
+      }
+    }
+
+    @media (max-width: 520px) {
+      .buttons {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: clamp(6px, 2vw, 12px);
+        justify-items: center;
+      }
+      .buttons a {
+        width: 100%;
+        flex-direction: column;
+        font-size: clamp(0.56rem, 2.8vw, 0.8rem);
+        padding: clamp(6px, 1.6vw + 2px, 10px) clamp(4px, 1.4vw + 2px, 12px);
+        gap: clamp(6px, 1.5vw + 2px, 10px);
+      }
+      .buttons svg {
+        width: 1.35em;
+        height: 1.35em;
+      }
+    }
 
     .social-section {
       max-width: 1200px;


### PR DESCRIPTION
## Summary
- keep the social button group in a single row by switching to a responsive flex/grid layout
- scale button spacing, font sizes, and icon sizes based on viewport width for better fit on small screens

## Testing
- not run (static changes)


------
https://chatgpt.com/codex/tasks/task_e_68c943a074648330afdc2fc9bcfd1241