### PR TITLE
Add support promos and refresh support icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,6 +263,75 @@
 
   <hr class="divider" />
 
+  <section class="home-support" aria-labelledby="home-support-title">
+    <div class="home-support__card">
+      <h2 class="home-support__title" id="home-support-title">Wesprzyj nasze wyprawy</h2>
+      <p class="home-support__lead">Chcesz pomóc w tworzeniu kolejnych filmów i wypraw ExploRide? 🙌</p>
+      <p class="home-support__lead">Twoje wsparcie pozwala nam działać dalej i rozwijać projekt.</p>
+      <p class="home-support__note">Formy wsparcia:</p>
+      <ul class="home-support__links">
+        <li>
+          <a class="home-support__link" href="https://buycoffee.to/exploride" target="_blank" rel="noopener noreferrer">
+            <span class="brand-icon brand-icon--sm brand-icon--buycoffee" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <path d="M5 7h11a2 2 0 0 1 2 2v1.5a3.5 3.5 0 0 1-3.2 3.5L13.9 19a2.2 2.2 0 0 1-2.2 1.9H9.3a2.2 2.2 0 0 1-2.2-1.9L6.1 14H5a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2z" fill="currentColor"></path>
+                <path d="M16 9h2.2a2 2 0 0 1 0 4H16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"></path>
+                <path d="M9 4.6c.7 0 1.3.6 1.3 1.3 0 .5-.2.9-.5 1.1M12 4.3c.7 0 1.3.6 1.3 1.3 0 .5-.2.8-.5 1" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"></path>
+              </svg>
+            </span>
+            <span>BuyCoffee</span>
+          </a>
+        </li>
+        <li>
+          <a class="home-support__link" href="https://www.youtube.com/channel/UCDDh55aHt6hRAjIu5BIkrUQ/join" target="_blank" rel="noopener noreferrer">
+            <span class="brand-icon brand-icon--sm brand-icon--youtube" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" fill="currentColor"></path>
+              </svg>
+            </span>
+            <span>YouTube</span>
+          </a>
+        </li>
+        <li>
+          <a class="home-support__link" href="https://www.facebook.com/ExploRideURBEX/subscribe/" target="_blank" rel="noopener noreferrer">
+            <span class="brand-icon brand-icon--sm brand-icon--facebook" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <path d="M9.101 23.691v-7.98H6.627v-3.667h2.474v-1.58c0-4.085 1.848-5.978 5.858-5.978.401 0 .955.042 1.468.103a8.68 8.68 0 0 1 1.141.195v3.325a8.623 8.623 0 0 0-.653-.036 26.805 26.805 0 0 0-.733-.009c-.707 0-1.259.096-1.675.309a1.686 1.686 0 0 0-.679.622c-.258.42-.374.995-.374 1.752v1.297h3.919l-.386 2.103-.287 1.564h-3.246v8.245C19.396 23.238 24 18.179 24 12.044c0-6.627-5.373-12-12-12S0 5.373 0 12c0 5.628 3.874 10.35 9.101 11.647Z" fill="currentColor"></path>
+              </svg>
+            </span>
+            <span>Facebook</span>
+          </a>
+        </li>
+        <li>
+          <a class="home-support__link" href="https://paypal.me/EXPLORIDE" target="_blank" rel="noopener noreferrer">
+            <span class="brand-icon brand-icon--sm brand-icon--paypal" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <path d="M9.4 5.4h4.5c2.2 0 3.7 1.2 3.7 3.1 0 2.2-1.9 3.6-4.5 3.6h-2l-.9 5.5H7.6l1.8-12.2z" fill="currentColor"></path>
+                <path d="M14.9 8.2h1.8c1 0 1.6.5 1.6 1.5 0 1.1-.9 1.7-2.1 1.7h-1.7z" fill="currentColor" opacity="0.55"></path>
+              </svg>
+            </span>
+            <span>PayPal</span>
+          </a>
+        </li>
+        <li>
+          <div class="home-support__link home-support__link--static">
+            <span class="brand-icon brand-icon--sm brand-icon--bank" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <path d="M4 9.3 12 4l8 5.3v1.4H4z" fill="currentColor"></path>
+                <rect x="5" y="11.2" width="14" height="7.6" rx="1.3" fill="currentColor" opacity="0.75"></rect>
+                <rect x="7" y="12.8" width="2.4" height="4.2" fill="currentColor"></rect>
+                <rect x="11" y="12.8" width="2.4" height="4.2" fill="currentColor"></rect>
+                <rect x="15" y="12.8" width="2.4" height="4.2" fill="currentColor"></rect>
+                <rect x="4" y="19.2" width="16" height="1.6" fill="currentColor"></rect>
+              </svg>
+            </span>
+            <span>Przelew <span class="home-support__account">76 1050 1894 1000 0097 2209 8382</span></span>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </section>
+
   <footer>
     © ExploRide • Urbex i podróże
   </footer>

--- a/style.css
+++ b/style.css
@@ -543,6 +543,135 @@
       }
     }
 
+    /* Ikony marek wykorzystywane w sekcjach wsparcia */
+    .brand-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 44px;
+      height: 44px;
+      border-radius: 12px;
+      flex-shrink: 0;
+      color: #fff;
+      box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
+    }
+    .brand-icon svg {
+      width: 24px;
+      height: 24px;
+      display: block;
+    }
+    .brand-icon--lg {
+      width: 48px;
+      height: 48px;
+    }
+    .brand-icon--sm {
+      width: 36px;
+      height: 36px;
+      border-radius: 10px;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+    }
+    .brand-icon--buycoffee {
+      background: linear-gradient(135deg, #ffe08a, #f5b63f);
+      color: #2c1600;
+    }
+    .brand-icon--youtube {
+      background: #ff0000;
+      color: #fff;
+    }
+    .brand-icon--facebook {
+      background: #1877f2;
+    }
+    .brand-icon--paypal {
+      background: linear-gradient(135deg, #003087, #009cde);
+      color: #fff;
+    }
+    .brand-icon--bank {
+      background: rgba(255, 255, 255, 0.12);
+      color: #ffdf91;
+    }
+
+    /* Mini sekcja wsparcia na stronie głównej */
+    .home-support {
+      max-width: 960px;
+      margin: 48px auto 0;
+      padding: 0 16px 60px;
+      color: #cfcfcf;
+      font-size: 0.94em;
+    }
+    .home-support__card {
+      background: rgba(17, 17, 17, 0.65);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 18px;
+      padding: 24px 22px;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      box-shadow: 0 12px 28px rgba(0, 0, 0, 0.28);
+    }
+    .home-support__title {
+      margin: 0;
+      font-size: 1.4em;
+      letter-spacing: 0.03em;
+      color: #e64b4b;
+    }
+    .home-support__lead {
+      margin: 0;
+      line-height: 1.55;
+    }
+    .home-support__note {
+      margin: 6px 0 0;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      font-size: 0.78em;
+      color: rgba(255, 255, 255, 0.6);
+    }
+    .home-support__links {
+      list-style: none;
+      margin: 4px 0 0;
+      padding: 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+    .home-support__link,
+    .home-support__link--static {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 8px 16px;
+      background: rgba(255, 255, 255, 0.05);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 999px;
+      color: #fff;
+      text-decoration: none;
+      transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+    }
+    .home-support__link:hover,
+    .home-support__link:focus-visible {
+      transform: translateY(-1px);
+      border-color: rgba(229, 9, 20, 0.9);
+      background: rgba(229, 9, 20, 0.18);
+      outline: none;
+    }
+    .home-support__link--static {
+      cursor: default;
+    }
+    .home-support__account {
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      color: rgba(255, 255, 255, 0.86);
+    }
+    @media (max-width: 520px) {
+      .home-support__links {
+        flex-direction: column;
+        gap: 8px;
+      }
+      .home-support__link,
+      .home-support__link--static {
+        justify-content: flex-start;
+      }
+    }
+
     /* Wesprzyj nas */
     .support-main {
       max-width: 960px;
@@ -592,9 +721,9 @@
     }
     .support-list li {
       display: flex;
-      align-items: flex-start;
-      gap: 12px;
-      padding: 12px 16px;
+      align-items: center;
+      gap: 16px;
+      padding: 12px 18px;
       background: rgba(255, 255, 255, 0.05);
       border: 1px solid rgba(255, 255, 255, 0.08);
       border-radius: 12px;
@@ -603,8 +732,20 @@
       line-height: 1.55;
     }
     .support-icon {
-      font-size: 1.6em;
-      line-height: 1;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 38px;
+      height: 38px;
+      border-radius: 12px;
+      background: rgba(229, 9, 20, 0.16);
+      color: #ff8b6a;
+      flex-shrink: 0;
+    }
+    .support-icon svg {
+      width: 22px;
+      height: 22px;
+      display: block;
     }
     .support-options {
       list-style: none;
@@ -634,10 +775,6 @@
       background: rgba(229, 9, 20, 0.14);
       outline: none;
     }
-    .support-option-icon {
-      font-size: 1.7em;
-      line-height: 1;
-    }
     .support-option-content {
       display: flex;
       flex-direction: column;
@@ -649,17 +786,15 @@
       font-weight: 700;
       letter-spacing: 0.01em;
     }
-    .support-option-link {
-      font-size: 0.95em;
-      color: rgba(255, 255, 255, 0.85);
-      word-break: break-word;
+    .support-option-desc {
+      font-size: 0.92em;
+      color: rgba(255, 255, 255, 0.7);
     }
-    .support-option-link code {
-      background: rgba(0, 0, 0, 0.3);
-      padding: 2px 6px;
-      border-radius: 6px;
+    .support-option-note {
       font-size: 0.95em;
-      color: #fff;
+      color: rgba(255, 255, 255, 0.82);
+      letter-spacing: 0.02em;
+      word-break: break-word;
     }
     .support-option--static {
       cursor: default;

--- a/wesprzyj-nas.html
+++ b/wesprzyj-nas.html
@@ -43,19 +43,47 @@
         <h2 class="support-heading">Twoje wsparcie pomaga nam:</h2>
         <ul class="support-list">
           <li>
-            <span class="support-icon" aria-hidden="true">🚗</span>
+            <span class="support-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <rect x="4" y="10" width="16" height="5.5" rx="1.6" fill="currentColor" opacity="0.85"></rect>
+                <path d="M7 7h10l1.6 3.5H5.4L7 7z" fill="currentColor"></path>
+                <circle cx="8" cy="17.2" r="1.8" fill="currentColor"></circle>
+                <circle cx="16" cy="17.2" r="1.8" fill="currentColor"></circle>
+              </svg>
+            </span>
             <span>docierać do coraz bardziej niezwykłych miejsc</span>
           </li>
           <li>
-            <span class="support-icon" aria-hidden="true">🎥</span>
+            <span class="support-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <rect x="4" y="8" width="11" height="10" rx="2" fill="currentColor"></rect>
+                <polygon points="16,11 20,9 20,15 16,13" fill="currentColor"></polygon>
+                <circle cx="9" cy="6.2" r="2.1" fill="currentColor" opacity="0.7"></circle>
+                <circle cx="14" cy="6.5" r="1.6" fill="currentColor" opacity="0.4"></circle>
+              </svg>
+            </span>
             <span>tworzyć lepsze filmy i fotografie</span>
           </li>
           <li>
-            <span class="support-icon" aria-hidden="true">🎙️</span>
+            <span class="support-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <rect x="9" y="4" width="6" height="10" rx="3" fill="currentColor"></rect>
+                <path d="M7 11a5 5 0 0 0 10 0v-1h-2v1a3 3 0 1 1-6 0v-1H7z" fill="currentColor" opacity="0.75"></path>
+                <rect x="11" y="15" width="2" height="5" rx="1" fill="currentColor"></rect>
+                <rect x="8" y="20" width="8" height="1.6" rx="0.8" fill="currentColor"></rect>
+              </svg>
+            </span>
             <span>nagrywać podcasty i reportaże z wyjątkowymi ludźmi</span>
           </li>
           <li>
-            <span class="support-icon" aria-hidden="true">🌍</span>
+            <span class="support-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <circle cx="12" cy="12" r="8.4" fill="none" stroke="currentColor" stroke-width="1.6"></circle>
+                <path d="M3.8 12h16.4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"></path>
+                <path d="M12 3.6c2.2 2.1 3.6 5.3 3.6 8.4s-1.4 6.3-3.6 8.4c-2.2-2.1-3.6-5.3-3.6-8.4s1.4-6.3 3.6-8.4z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"></path>
+                <path d="M7.4 6.2c1.3.9 2.9 1.4 4.6 1.4s3.3-.5 4.6-1.4M16.6 17.8c-1.3-.9-2.9-1.4-4.6-1.4s-3.3.5-4.6 1.4" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"></path>
+              </svg>
+            </span>
             <span>dzielić się tym wszystkim z coraz szerszą społecznością</span>
           </li>
         </ul>
@@ -65,19 +93,48 @@
         <h2 class="support-heading">Wspierając nas na YouTube i Facebooku otrzymasz dostęp do ciekawych bonusów:</h2>
         <ul class="support-list">
           <li>
-            <span class="support-icon" aria-hidden="true">🎁</span>
+            <span class="support-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <rect x="3.2" y="10.2" width="17.6" height="10.6" rx="2" fill="currentColor" opacity="0.85"></rect>
+                <rect x="3.2" y="13" width="17.6" height="2.6" fill="currentColor"></rect>
+                <rect x="10.4" y="10.2" width="3.2" height="10.6" fill="currentColor"></rect>
+                <circle cx="8.6" cy="7.7" r="1.9" fill="currentColor"></circle>
+                <circle cx="15.4" cy="7.7" r="1.9" fill="currentColor"></circle>
+                <rect x="8.5" y="8.6" width="7" height="1.8" fill="currentColor"></rect>
+              </svg>
+            </span>
             <span>specjalne gadżety</span>
           </li>
           <li>
-            <span class="support-icon" aria-hidden="true">🎬</span>
+            <span class="support-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <circle cx="12" cy="12" r="8.4" fill="none" stroke="currentColor" stroke-width="1.6"></circle>
+                <path d="M12 7.6v4.6l3.2 1.7" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"></path>
+                <polygon points="14.6,10.2 18.2,12 14.6,13.8" fill="currentColor" opacity="0.35"></polygon>
+              </svg>
+            </span>
             <span>wcześniejszy dostęp do filmów</span>
           </li>
           <li>
-            <span class="support-icon" aria-hidden="true">🔒</span>
+            <span class="support-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <rect x="7" y="11" width="10" height="9" rx="2" fill="currentColor" opacity="0.9"></rect>
+                <path d="M9 11V8.6a3 3 0 0 1 6 0V11" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"></path>
+                <circle cx="12" cy="15" r="1.4" fill="none" stroke="currentColor" stroke-width="1.6"></circle>
+                <rect x="11.3" y="15" width="1.4" height="2.6" rx="0.7" fill="currentColor"></rect>
+              </svg>
+            </span>
             <span>materiały publikowane tylko dla wspierających</span>
           </li>
           <li>
-            <span class="support-icon" aria-hidden="true">👥</span>
+            <span class="support-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <circle cx="9" cy="11" r="2.6" fill="currentColor"></circle>
+                <circle cx="16" cy="11.6" r="2.2" fill="currentColor" opacity="0.6"></circle>
+                <path d="M5.6 18c.8-2.1 2.9-3.5 5.4-3.5s4.6 1.4 5.4 3.5H5.6z" fill="currentColor"></path>
+                <path d="M14 17.3c.6-1.3 1.8-2.1 3.4-2.1 1.1 0 2.1.4 2.9 1.1" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.6"></path>
+              </svg>
+            </span>
             <span>dostęp do tajnych grup społeczności</span>
           </li>
         </ul>
@@ -88,46 +145,74 @@
         <ul class="support-options">
           <li>
             <a class="support-option" href="https://buycoffee.to/exploride" target="_blank" rel="noopener noreferrer">
-              <span class="support-option-icon" aria-hidden="true">☕</span>
+              <span class="brand-icon brand-icon--lg brand-icon--buycoffee" aria-hidden="true">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                  <path d="M5 7h11a2 2 0 0 1 2 2v1.5a3.5 3.5 0 0 1-3.2 3.5L13.9 19a2.2 2.2 0 0 1-2.2 1.9H9.3a2.2 2.2 0 0 1-2.2-1.9L6.1 14H5a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2z" fill="currentColor"></path>
+                  <path d="M16 9h2.2a2 2 0 0 1 0 4H16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"></path>
+                  <path d="M9 4.6c.7 0 1.3.6 1.3 1.3 0 .5-.2.9-.5 1.1M12 4.3c.7 0 1.3.6 1.3 1.3 0 .5-.2.8-.5 1" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"></path>
+                </svg>
+              </span>
               <span class="support-option-content">
                 <span class="support-option-name">BuyCoffee</span>
-                <span class="support-option-link">buycoffee.to/exploride</span>
+                <span class="support-option-desc">Postaw nam kawę i wesprzyj wyprawy.</span>
               </span>
             </a>
           </li>
           <li>
-            <a class="support-option" href="https://www.youtube.com/c/@ExploRideURBEX/join" target="_blank" rel="noopener noreferrer">
-              <span class="support-option-icon" aria-hidden="true">▶️</span>
+            <a class="support-option" href="https://www.youtube.com/channel/UCDDh55aHt6hRAjIu5BIkrUQ/join" target="_blank" rel="noopener noreferrer">
+              <span class="brand-icon brand-icon--lg brand-icon--youtube" aria-hidden="true">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                  <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" fill="currentColor"></path>
+                </svg>
+              </span>
               <span class="support-option-content">
-                <span class="support-option-name">Wsparcie na YouTube</span>
-                <span class="support-option-link">youtube.com/c/@ExploRideURBEX/join</span>
+                <span class="support-option-name">YouTube</span>
+                <span class="support-option-desc">Dołącz do członkostwa kanału.</span>
               </span>
             </a>
           </li>
           <li>
             <a class="support-option" href="https://www.facebook.com/ExploRideURBEX/subscribe/" target="_blank" rel="noopener noreferrer">
-              <span class="support-option-icon" aria-hidden="true">📘</span>
+              <span class="brand-icon brand-icon--lg brand-icon--facebook" aria-hidden="true">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                  <path d="M9.101 23.691v-7.98H6.627v-3.667h2.474v-1.58c0-4.085 1.848-5.978 5.858-5.978.401 0 .955.042 1.468.103a8.68 8.68 0 0 1 1.141.195v3.325a8.623 8.623 0 0 0-.653-.036 26.805 26.805 0 0 0-.733-.009c-.707 0-1.259.096-1.675.309a1.686 1.686 0 0 0-.679.622c-.258.42-.374.995-.374 1.752v1.297h3.919l-.386 2.103-.287 1.564h-3.246v8.245C19.396 23.238 24 18.179 24 12.044c0-6.627-5.373-12-12-12S0 5.373 0 12c0 5.628 3.874 10.35 9.101 11.647Z" fill="currentColor"></path>
+                </svg>
+              </span>
               <span class="support-option-content">
-                <span class="support-option-name">Subskrypcje na Facebooku</span>
-                <span class="support-option-link">facebook.com/ExploRideURBEX/subscribe</span>
+                <span class="support-option-name">Facebook</span>
+                <span class="support-option-desc">Włącz subskrypcję wspierających.</span>
               </span>
             </a>
           </li>
           <li>
             <a class="support-option" href="https://paypal.me/EXPLORIDE" target="_blank" rel="noopener noreferrer">
-              <span class="support-option-icon" aria-hidden="true">💳</span>
+              <span class="brand-icon brand-icon--lg brand-icon--paypal" aria-hidden="true">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                  <path d="M9.4 5.4h4.5c2.2 0 3.7 1.2 3.7 3.1 0 2.2-1.9 3.6-4.5 3.6h-2l-.9 5.5H7.6l1.8-12.2z" fill="currentColor"></path>
+                  <path d="M14.9 8.2h1.8c1 0 1.6.5 1.6 1.5 0 1.1-.9 1.7-2.1 1.7h-1.7z" fill="currentColor" opacity="0.55"></path>
+                </svg>
+              </span>
               <span class="support-option-content">
                 <span class="support-option-name">PayPal</span>
-                <span class="support-option-link">paypal.me/EXPLORIDE</span>
+                <span class="support-option-desc">Wyślij jednorazowe lub cykliczne wsparcie.</span>
               </span>
             </a>
           </li>
           <li>
             <div class="support-option support-option--static">
-              <span class="support-option-icon" aria-hidden="true">🏦</span>
+              <span class="brand-icon brand-icon--lg brand-icon--bank" aria-hidden="true">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                  <path d="M4 9.3 12 4l8 5.3v1.4H4z" fill="currentColor"></path>
+                  <rect x="5" y="11.2" width="14" height="7.6" rx="1.3" fill="currentColor" opacity="0.75"></rect>
+                  <rect x="7" y="12.8" width="2.4" height="4.2" fill="currentColor"></rect>
+                  <rect x="11" y="12.8" width="2.4" height="4.2" fill="currentColor"></rect>
+                  <rect x="15" y="12.8" width="2.4" height="4.2" fill="currentColor"></rect>
+                  <rect x="4" y="19.2" width="16" height="1.6" fill="currentColor"></rect>
+                </svg>
+              </span>
               <span class="support-option-content">
                 <span class="support-option-name">Przelew bankowy</span>
-                <span class="support-option-link"><code>76 1050 1894 1000 0097 2209 8382</code></span>
+                <span class="support-option-note">76 1050 1894 1000 0097 2209 8382</span>
               </span>
             </div>
           </li>


### PR DESCRIPTION
## Summary
- add a subtle “Wesprzyj nas” section to the home page with compact copy and brand buttons
- introduce shared brand icon styles and update the support page to replace emoji with matching icons and descriptions
- ensure support links point to the requested URLs without exposing the raw addresses

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c95110ef5c833088a0aed50d5f2cd3