### PR TITLE
Redesign Facebook post layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,14 @@
     </div>
   </div>
 
-  <div id="fb-feed" class="fb-grid"></div>
+  <div id="fb-feed" class="fb-feed">
+    <div id="fb-featured" class="fb-featured" aria-live="polite"></div>
+    <div id="fb-carousel-window" class="fb-carousel-window" style="display:none;" tabindex="0">
+      <button id="fbBtnPrev" class="nav-btn left" aria-label="Pokaż wcześniejsze posty">&#9664;</button>
+      <div id="fb-carousel" class="fb-carousel"></div>
+      <button id="fbBtnNext" class="nav-btn right" aria-label="Pokaż kolejne posty">&#9654;</button>
+    </div>
+  </div>
   <!-- ======== /Facebook: Najnowsze posty ======== -->
 
   <hr class="divider" />
@@ -342,6 +349,11 @@
     const FB_PAGE_ID = "145171925888318";   // Twoje Page ID
     const FB_LIMIT   = 6;                   // ile postów pokazać
 
+    let fbCarousel = null;
+    let fbBtnPrev = null;
+    let fbBtnNext = null;
+    let fbCarouselBound = false;
+
     const esc = (s = "") => s.replaceAll("<", "&lt;");
 
     const fmtDatePL = iso => {
@@ -349,10 +361,13 @@
       return `${String(d.getDate()).padStart(2, "0")}.${String(d.getMonth() + 1).padStart(2, "0")}.${d.getFullYear()}`;
     };
 
-    const postCard = p => {
+    const postCard = (p, variant = "grid") => {
       const firstImg = (p.media && p.media.length) ? p.media[0].src : null;
+      const classes = ["fb-card"];
+      if (variant === "featured") classes.push("fb-card--featured");
+      if (variant === "carousel") classes.push("fb-card--carousel");
       return `
-        <a class="fb-card" href="${p.permalink_url}" target="_blank" rel="noopener">
+        <a class="${classes.join(" ")}" href="${p.permalink_url}" target="_blank" rel="noopener">
           ${firstImg ? `<div class="fb-media"><img src="${firstImg}" alt="Post ExploRide" loading="lazy"></div>` : ""}
           <div class="fb-body">
             <div class="fb-date">${fmtDatePL(p.created_time)}</div>
@@ -362,10 +377,33 @@
       `;
     };
 
+    function updateFbNav() {
+      if (!fbCarousel || !fbBtnPrev || !fbBtnNext) return;
+      const canScroll = fbCarousel.scrollWidth > fbCarousel.clientWidth + 1;
+      if (!canScroll) {
+        fbBtnPrev.style.display = "none";
+        fbBtnNext.style.display = "none";
+        return;
+      }
+
+      fbBtnPrev.style.display = fbCarousel.scrollLeft > 0 ? "block" : "none";
+      const maxScrollLeft = fbCarousel.scrollWidth - fbCarousel.clientWidth - 1;
+      fbBtnNext.style.display = fbCarousel.scrollLeft < maxScrollLeft ? "block" : "none";
+    }
+
+    function scrollFb(offset) {
+      if (!fbCarousel) return;
+      fbCarousel.scrollBy({ left: offset, behavior: "smooth" });
+    }
+
     async function loadFbFeed() {
       const loader = document.getElementById("fb-feed-loader");
       const fallback = document.getElementById("fb-feed-fallback");
-      const grid = document.getElementById("fb-feed");
+      const featured = document.getElementById("fb-featured");
+      const carouselWindow = document.getElementById("fb-carousel-window");
+      fbCarousel = document.getElementById("fb-carousel");
+      fbBtnPrev = document.getElementById("fbBtnPrev");
+      fbBtnNext = document.getElementById("fbBtnNext");
       try {
         const url = new URL(WORKER_URL);
         url.searchParams.set("page_id", FB_PAGE_ID);
@@ -377,7 +415,48 @@
         const items = data.items || [];
         if (!items.length) throw new Error("Brak postów");
 
-        grid.innerHTML = items.map(postCard).join("");
+        const [latest, ...rest] = items;
+
+        if (latest && featured) {
+          featured.innerHTML = postCard(latest, "featured");
+          featured.style.display = "block";
+        } else if (featured) {
+          featured.innerHTML = "";
+          featured.style.display = "none";
+        }
+
+        if (rest.length && fbCarousel && carouselWindow) {
+          fbCarousel.innerHTML = rest.map(p => postCard(p, "carousel")).join("");
+          carouselWindow.style.display = "block";
+
+          if (!fbCarouselBound && fbBtnPrev && fbBtnNext) {
+            fbBtnPrev.addEventListener("click", () => scrollFb(-fbCarousel.clientWidth));
+            fbBtnNext.addEventListener("click", () => scrollFb(fbCarousel.clientWidth));
+            fbCarousel.addEventListener("scroll", updateFbNav);
+            if (carouselWindow) {
+              carouselWindow.addEventListener("keydown", e => {
+                if (e.key === "ArrowLeft") {
+                  e.preventDefault();
+                  scrollFb(-fbCarousel.clientWidth);
+                } else if (e.key === "ArrowRight") {
+                  e.preventDefault();
+                  scrollFb(fbCarousel.clientWidth);
+                }
+              });
+            }
+            window.addEventListener("resize", updateFbNav);
+            fbCarouselBound = true;
+          }
+
+          const raf = window.requestAnimationFrame
+            ? window.requestAnimationFrame.bind(window)
+            : fn => setTimeout(fn, 0);
+          raf(updateFbNav);
+        } else if (fbCarousel && carouselWindow) {
+          fbCarousel.innerHTML = "";
+          carouselWindow.style.display = "none";
+        }
+
         loader.style.display = "none";
       } catch (e) {
         console.warn("FB feed error", e);

--- a/style.css
+++ b/style.css
@@ -297,8 +297,12 @@
       width: 240px;
       flex: 0 0 240px;
       height: auto;
+      text-decoration: none;
+      color: inherit;
     }
     .video-tile:hover { transform: translateY(-3px); }
+    .video-tile:visited { color: inherit; }
+    .video-tile:focus-visible { outline: 2px solid #e50914; outline-offset: 3px; }
     .thumb {
       position: relative;
       width: 100%;
@@ -343,16 +347,36 @@
     }
 
     /* Facebook feed */
-    .fb-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 16px;
+    .fb-feed {
       max-width: 1200px;
       margin: 18px auto 40px;
       padding: 0 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 28px;
     }
+    .fb-featured:empty {
+      display: none;
+    }
+    .fb-carousel-window {
+      position: relative;
+      overflow: hidden;
+      display: none;
+    }
+    .fb-carousel-window:focus { outline: none; }
+    .fb-carousel {
+      display: flex;
+      gap: 18px;
+      overflow-x: auto;
+      scroll-behavior: smooth;
+      align-items: stretch;
+      padding-bottom: 4px;
+      -ms-overflow-style: none;
+      scrollbar-width: none;
+    }
+    .fb-carousel::-webkit-scrollbar { display: none; }
     .fb-card {
-      background: #eeeeee;
+      background: #f1f1f1;
       border: 1px solid #2a2a2a;
       border-radius: 12px;
       overflow: hidden;
@@ -360,14 +384,34 @@
       flex-direction: column;
       text-align: left;
       transition: transform 0.2s ease;
+      text-decoration: none;
+      color: inherit;
     }
+    .fb-card:visited { color: inherit; }
     .fb-card:hover { transform: translateY(-3px); }
+    .fb-card:focus-visible { outline: 2px solid #e50914; outline-offset: 3px; }
+    .fb-card--featured {
+      display: grid;
+      grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+      gap: 24px;
+      padding: 18px;
+    }
+    .fb-card--carousel {
+      flex: 0 0 300px;
+      width: 300px;
+    }
     .fb-media {
       position: relative;
       width: 100%;
       padding-top: 56.25%;
       background: #000;
       overflow: hidden;
+    }
+    .fb-card--featured .fb-media {
+      padding-top: 0;
+      aspect-ratio: 16 / 9;
+      border-radius: 12px;
+      min-height: 260px;
     }
     .fb-media img {
       position: absolute;
@@ -377,19 +421,57 @@
       object-fit: cover;
       display: block;
     }
+    .fb-card--featured .fb-media img {
+      border-radius: 12px;
+    }
     .fb-body { padding: 12px 14px; }
+    .fb-card--featured .fb-body {
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      justify-content: center;
+    }
     .fb-date {
-      font-size: 0.85em;
-      color: #303030;
+      font-size: 0.9em;
+      color: #2c2c2c;
       margin-bottom: 6px;
+    }
+    .fb-card--featured .fb-date {
+      font-size: 0.95em;
+      color: #1c1c1c;
     }
     .fb-text {
       white-space: pre-wrap;
-      color: #000000;
+      color: #111111;
       font-size: 0.98em;
       line-height: 1.35;
       max-height: 6.5em;
       overflow: hidden;
+    }
+    .fb-card--featured .fb-text {
+      max-height: none;
+      font-size: 1.05em;
+      line-height: 1.45;
+    }
+    .fb-card--carousel .fb-text {
+      max-height: 5.4em;
+    }
+
+    @media (max-width: 1024px) {
+      .fb-card--featured {
+        grid-template-columns: 1fr;
+      }
+      .fb-card--featured .fb-body {
+        padding-top: 12px;
+      }
+    }
+
+    @media (max-width: 600px) {
+      .fb-card--carousel {
+        flex: 0 0 260px;
+        width: 260px;
+      }
     }
 
     /* O nas */


### PR DESCRIPTION
## Summary
- highlight the newest Facebook post in a featured card above the feed
- render the remaining posts inside a horizontal carousel with next/prev controls
- polish styles so Facebook cards and video tiles lose default link underlines while keeping accessible focus states

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c9592a55488330851849e5da3779d0