### PR TITLE
Render Facebook featured cards as multi-image collage

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,13 +362,28 @@
     };
 
     const postCard = (p, variant = "grid") => {
-      const firstImg = (p.media && p.media.length) ? p.media[0].src : null;
+      const media = Array.isArray(p.media) ? p.media.filter(m => m && m.src) : [];
+      const firstImg = media[0]?.src || null;
       const classes = ["fb-card"];
       if (variant === "featured") classes.push("fb-card--featured");
       if (variant === "carousel") classes.push("fb-card--carousel");
+      let mediaHtml = "";
+      if (variant === "featured" && media.length > 1) {
+        const extraCount = media.length - 4;
+        const multiClasses = ["fb-media", "fb-media--multi"];
+        if (extraCount > 0) multiClasses.push("fb-media--multi--more");
+        const collage = media
+          .slice(0, 4)
+          .map((m, idx) => `<img src="${m.src}" alt="Post ExploRide – zdjęcie ${idx + 1}" loading="lazy">`)
+          .join("");
+        const overlay = extraCount > 0 ? `<span class="fb-media__more" aria-hidden="true">+${extraCount}</span>` : "";
+        mediaHtml = `<div class="${multiClasses.join(" ")}">${collage}${overlay}</div>`;
+      } else if (firstImg) {
+        mediaHtml = `<div class="fb-media"><img src="${firstImg}" alt="Post ExploRide" loading="lazy"></div>`;
+      }
       return `
         <a class="${classes.join(" ")}" href="${p.permalink_url}" target="_blank" rel="noopener">
-          ${firstImg ? `<div class="fb-media"><img src="${firstImg}" alt="Post ExploRide" loading="lazy"></div>` : ""}
+          ${mediaHtml}
           <div class="fb-body">
             <div class="fb-date">${fmtDatePL(p.created_time)}</div>
             <div class="fb-text">${esc(p.message || "")}</div>

--- a/style.css
+++ b/style.css
@@ -421,7 +421,47 @@
       object-fit: cover;
       display: block;
     }
-    .fb-card--featured .fb-media img {
+    .fb-media--multi {
+      padding-top: 0;
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      grid-template-rows: repeat(2, 1fr);
+      gap: 2px;
+      background: #000;
+      aspect-ratio: 1;
+    }
+    .fb-card--featured .fb-media--multi {
+      aspect-ratio: 16 / 9;
+      border-radius: 12px;
+    }
+    .fb-media--multi img {
+      position: static;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+    .fb-media--multi img:first-child { border-top-left-radius: 12px; }
+    .fb-media--multi img:nth-child(2) { border-top-right-radius: 12px; }
+    .fb-media--multi img:nth-child(3) { border-bottom-left-radius: 12px; }
+    .fb-media--multi img:nth-child(4) { border-bottom-right-radius: 12px; }
+    .fb-media--multi--more img:nth-of-type(4) {
+      filter: brightness(0.6);
+    }
+    .fb-media__more {
+      position: absolute;
+      right: 12px;
+      bottom: 12px;
+      padding: 6px 12px;
+      border-radius: 999px;
+      background: rgba(0, 0, 0, 0.7);
+      color: #fff;
+      font-size: 1.05em;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+      pointer-events: none;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+    }
+    .fb-card--featured .fb-media:not(.fb-media--multi) img {
       border-radius: 12px;
     }
     .fb-body { padding: 12px 14px; }


### PR DESCRIPTION
## Summary
- render a 2×2 collage for featured Facebook cards when multiple media items are available and add a +N badge for overflow
- add CSS grid styling for the collage layout, rounded corners, and overlay badge appearance

## Testing
- python3 -m http.server 8000 (manual Playwright inspection)
- node - <<'NODE' … (verifies collage markup output)


------
https://chatgpt.com/codex/tasks/task_e_68c95ede65c483308a436ac9be60a135