### PR TITLE
Reduce featured Facebook card width

### DIFF
--- a/style.css
+++ b/style.css
@@ -355,6 +355,11 @@
       flex-direction: column;
       gap: 28px;
     }
+    .fb-featured {
+      align-self: center;
+      width: 100%;
+      max-width: 600px;
+    }
     .fb-featured:empty {
       display: none;
     }


### PR DESCRIPTION
## Summary
- limit the width of the featured Facebook post container so it renders at half the feed width on large screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c97c0333cc8330b6a00caf28aa0134