### PR TITLE
Add hero banner to about page

### DIFF
--- a/onas.html
+++ b/onas.html
@@ -35,6 +35,9 @@
   <main class="about-main">
     <article class="about-card">
       <h1>O nas</h1>
+      <figure class="about-figure">
+        <img src="Photos/banner.jpg" alt="Panoramiczne ujęcie eksplorowanych miejsc" class="about-photo">
+      </figure>
       <div class="about-text">
         <p>ExploRide to projekt tworzony z pasji do odkrywania miejsc, o których większość już zapomniała.</p>
         <p>Łączymy urbex, podróże i historię w jedną opowieść – pokazujemy opuszczone budynki, dawne fabryki, schrony czy zapomniane wille, a także piękne zakątki natury, które spotykamy w drodze.</p>

--- a/style.css
+++ b/style.css
@@ -561,6 +561,8 @@
     }
     .about-photo {
       width: 100%;
+      display: block;
+      margin: 0 auto;
       border-radius: 16px;
       border: 1px solid #2a2a2a;
       box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);


### PR DESCRIPTION
## Summary
- add a banner image to the top of the About page content
- ensure about page photos are centered within their container

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ca0069c2c08330aee4443ea1a89466