### PR TITLE
Adjust featured Facebook post presentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -380,6 +380,21 @@
 
     const esc = (s = "") => s.replaceAll("<", "&lt;");
 
+    const shortenText = (text = "", limit = 600) => {
+      const value = (text || "").trim();
+      if (!value) {
+        return { value: "", truncated: false };
+      }
+      if (value.length <= limit) {
+        return { value, truncated: false };
+      }
+      const slice = value.slice(0, limit);
+      const withoutLastWord = slice.replace(/\s+\S*$/, "");
+      const safe = withoutLastWord.length > limit * 0.4 ? withoutLastWord : slice;
+      const finalValue = safe.replace(/[\s\n]+$/u, "");
+      return { value: finalValue + "…", truncated: true };
+    };
+
     const fmtDatePL = iso => {
       const d = new Date(iso); if (isNaN(d)) return "";
       return `${String(d.getDate()).padStart(2, "0")}.${String(d.getMonth() + 1).padStart(2, "0")}.${d.getFullYear()}`;
@@ -392,7 +407,13 @@
       if (variant === "featured") classes.push("fb-card--featured");
       if (variant === "carousel") classes.push("fb-card--carousel");
       let mediaHtml = "";
-      if (variant === "featured" && media.length > 1) {
+      if (variant === "featured" && media.length) {
+        const galleryItems = media
+          .map((m, idx) => `<div class="fb-gallery__item"><img src="${m.src}" alt="Post ExploRide – zdjęcie ${idx + 1}" loading="lazy"></div>`)
+          .join("");
+        const galleryAttrs = media.length > 1 ? " data-has-multiple=\"true\"" : "";
+        mediaHtml = `<div class="fb-gallery"${galleryAttrs} aria-label="Galeria zdjęć z posta">${galleryItems}</div>`;
+      } else if (media.length > 1) {
         const extraCount = media.length - 4;
         const multiClasses = ["fb-media", "fb-media--multi"];
         if (extraCount > 0) multiClasses.push("fb-media--multi--more");
@@ -405,12 +426,23 @@
       } else if (firstImg) {
         mediaHtml = `<div class="fb-media"><img src="${firstImg}" alt="Post ExploRide" loading="lazy"></div>`;
       }
+
+      const message = typeof p.message === "string" ? p.message : "";
+      let textData = { value: message, truncated: false };
+      if (variant === "featured") {
+        textData = shortenText(message, 600);
+      }
+      const textClasses = ["fb-text"];
+      if (variant === "featured" && textData.truncated) {
+        textClasses.push("fb-text--truncated");
+      }
+
       return `
         <a class="${classes.join(" ")}" href="${p.permalink_url}" target="_blank" rel="noopener">
           ${mediaHtml}
           <div class="fb-body">
             <div class="fb-date">${fmtDatePL(p.created_time)}</div>
-            <div class="fb-text">${esc(p.message || "")}</div>
+            <div class="${textClasses.join(" ")}">${esc(textData.value)}</div>
           </div>
         </a>
       `;

--- a/style.css
+++ b/style.css
@@ -417,6 +417,53 @@
       border-radius: 12px;
       min-height: 260px;
     }
+    .fb-gallery {
+      width: 100%;
+      display: flex;
+      flex-wrap: nowrap;
+      gap: 12px;
+      padding-bottom: 4px;
+      overflow-x: auto;
+      scroll-snap-type: x mandatory;
+      -webkit-overflow-scrolling: touch;
+      -ms-overflow-style: auto;
+      scrollbar-width: thin;
+      scrollbar-color: rgba(255, 255, 255, 0.35) rgba(255, 255, 255, 0.08);
+      background: #000;
+      border-radius: 12px;
+    }
+    .fb-gallery[data-has-multiple="true"] {
+      cursor: grab;
+    }
+    .fb-gallery::-webkit-scrollbar {
+      height: 8px;
+    }
+    .fb-gallery::-webkit-scrollbar-track {
+      background: rgba(255, 255, 255, 0.08);
+      border-radius: 999px;
+    }
+    .fb-gallery::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.35);
+      border-radius: 999px;
+    }
+    .fb-gallery__item {
+      flex: 0 0 100%;
+      position: relative;
+      aspect-ratio: 16 / 9;
+      min-height: 260px;
+      scroll-snap-align: center;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #000;
+      border-radius: 12px;
+    }
+    .fb-gallery__item img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      background: #000;
+    }
     .fb-media img {
       position: absolute;
       inset: 0;
@@ -478,7 +525,7 @@
       display: flex;
       flex-direction: column;
       gap: 14px;
-      justify-content: center;
+      justify-content: flex-start;
     }
     .fb-date {
       font-size: 0.9em;
@@ -501,6 +548,26 @@
       max-height: none;
       font-size: 1.05em;
       line-height: 1.45;
+    }
+    .fb-text--truncated {
+      position: relative;
+      overflow: hidden;
+    }
+    .fb-card--featured .fb-text--truncated {
+      max-height: 8.7em;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 6;
+    }
+    .fb-text--truncated::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      height: 2.1em;
+      background: linear-gradient(180deg, rgba(241, 241, 241, 0) 0%, #f1f1f1 85%);
+      pointer-events: none;
     }
     .fb-card--carousel .fb-text {
       max-height: 5.4em;


### PR DESCRIPTION
## Summary
- skróciłem wyświetlaną treść wyróżnionego posta z Facebooka, aby karta była niższa
- dodałem poziomą galerię zdjęć w wyróżnionym poście i usunąłem licznik fotografii, tak aby pokazywać całe zdjęcia bez przycięć

## Testing
- not run (statyczna strona)

------
https://chatgpt.com/codex/tasks/task_e_68ca72fb878483308e21e9c54f1b7857