### PR TITLE
Adjust Facebook feed layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -407,22 +407,19 @@
       if (variant === "featured") classes.push("fb-card--featured");
       if (variant === "carousel") classes.push("fb-card--carousel");
       let mediaHtml = "";
-      if (variant === "featured" && media.length) {
-        const galleryItems = media
-          .map((m, idx) => `<div class="fb-gallery__item"><img src="${m.src}" alt="Post ExploRide – zdjęcie ${idx + 1}" loading="lazy"></div>`)
+      if (variant === "featured" && media.length > 1) {
+        const limitedMedia = media.slice(0, 5);
+        const extraCount = Math.max(media.length - limitedMedia.length, 0);
+        const gridAttrs = ` data-count="${limitedMedia.length}"`;
+        const gridItems = limitedMedia
+          .map((m, idx) => {
+            const overlay = extraCount > 0 && idx === limitedMedia.length - 1
+              ? `<span class="fb-media__more" aria-hidden="true">+${extraCount}</span>`
+              : "";
+            return `<div class="fb-featured-media-grid__item"><img src="${m.src}" alt="Post ExploRide – zdjęcie ${idx + 1}" loading="lazy">${overlay}</div>`;
+          })
           .join("");
-        const galleryAttrs = media.length > 1 ? " data-has-multiple=\"true\"" : "";
-        mediaHtml = `<div class="fb-gallery"${galleryAttrs} aria-label="Galeria zdjęć z posta">${galleryItems}</div>`;
-      } else if (media.length > 1) {
-        const extraCount = media.length - 4;
-        const multiClasses = ["fb-media", "fb-media--multi"];
-        if (extraCount > 0) multiClasses.push("fb-media--multi--more");
-        const collage = media
-          .slice(0, 4)
-          .map((m, idx) => `<img src="${m.src}" alt="Post ExploRide – zdjęcie ${idx + 1}" loading="lazy">`)
-          .join("");
-        const overlay = extraCount > 0 ? `<span class="fb-media__more" aria-hidden="true">+${extraCount}</span>` : "";
-        mediaHtml = `<div class="${multiClasses.join(" ")}">${collage}${overlay}</div>`;
+        mediaHtml = `<div class="fb-featured-media-grid"${gridAttrs} role="group" aria-label="Galeria zdjęć z posta">${gridItems}</div>`;
       } else if (firstImg) {
         mediaHtml = `<div class="fb-media"><img src="${firstImg}" alt="Post ExploRide" loading="lazy"></div>`;
       }
@@ -432,17 +429,23 @@
       if (variant === "featured") {
         textData = shortenText(message, 600);
       }
-      const textClasses = ["fb-text"];
+      const textContentClasses = ["fb-text__content"];
       if (variant === "featured" && textData.truncated) {
-        textClasses.push("fb-text--truncated");
+        textContentClasses.push("fb-text__content--truncated");
       }
+      const moreLabel = variant === "featured" && textData.truncated
+        ? `<div class="fb-text__more">Kliknij i zobacz więcej</div>`
+        : "";
 
       return `
         <a class="${classes.join(" ")}" href="${p.permalink_url}" target="_blank" rel="noopener">
           ${mediaHtml}
           <div class="fb-body">
             <div class="fb-date">${fmtDatePL(p.created_time)}</div>
-            <div class="${textClasses.join(" ")}">${esc(textData.value)}</div>
+            <div class="fb-text">
+              <div class="${textContentClasses.join(" ")}">${esc(textData.value)}</div>
+              ${moreLabel}
+            </div>
           </div>
         </a>
       `;

--- a/style.css
+++ b/style.css
@@ -417,52 +417,64 @@
       border-radius: 12px;
       min-height: 260px;
     }
-    .fb-gallery {
+    .fb-featured-media-grid {
+      position: relative;
+      display: grid;
+      grid-template-columns: repeat(6, 1fr);
+      grid-template-rows: 3fr 2fr;
+      gap: 6px;
       width: 100%;
-      display: flex;
-      flex-wrap: nowrap;
-      gap: 12px;
-      padding-bottom: 4px;
-      overflow-x: auto;
-      scroll-snap-type: x mandatory;
-      -webkit-overflow-scrolling: touch;
-      -ms-overflow-style: auto;
-      scrollbar-width: thin;
-      scrollbar-color: rgba(255, 255, 255, 0.35) rgba(255, 255, 255, 0.08);
       background: #000;
       border-radius: 12px;
-    }
-    .fb-gallery[data-has-multiple="true"] {
-      cursor: grab;
-    }
-    .fb-gallery::-webkit-scrollbar {
-      height: 8px;
-    }
-    .fb-gallery::-webkit-scrollbar-track {
-      background: rgba(255, 255, 255, 0.08);
-      border-radius: 999px;
-    }
-    .fb-gallery::-webkit-scrollbar-thumb {
-      background: rgba(255, 255, 255, 0.35);
-      border-radius: 999px;
-    }
-    .fb-gallery__item {
-      flex: 0 0 100%;
-      position: relative;
+      overflow: hidden;
       aspect-ratio: 16 / 9;
       min-height: 260px;
-      scroll-snap-align: center;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: #000;
-      border-radius: 12px;
     }
-    .fb-gallery__item img {
+    .fb-featured-media-grid__item {
+      position: relative;
+      overflow: hidden;
+      background: #000;
+    }
+    .fb-featured-media-grid__item:nth-child(1) {
+      grid-column: 1 / span 3;
+      grid-row: 1;
+    }
+    .fb-featured-media-grid__item:nth-child(2) {
+      grid-column: 4 / span 3;
+      grid-row: 1;
+    }
+    .fb-featured-media-grid__item:nth-child(3) {
+      grid-column: 1 / span 2;
+      grid-row: 2;
+    }
+    .fb-featured-media-grid__item:nth-child(4) {
+      grid-column: 3 / span 2;
+      grid-row: 2;
+    }
+    .fb-featured-media-grid__item:nth-child(5) {
+      grid-column: 5 / span 2;
+      grid-row: 2;
+    }
+    .fb-featured-media-grid[data-count="2"] {
+      grid-template-rows: 1fr;
+    }
+    .fb-featured-media-grid[data-count="3"] .fb-featured-media-grid__item:nth-child(3) {
+      grid-column: 1 / span 6;
+      grid-row: 2;
+    }
+    .fb-featured-media-grid[data-count="4"] .fb-featured-media-grid__item:nth-child(3) {
+      grid-column: 1 / span 3;
+      grid-row: 2;
+    }
+    .fb-featured-media-grid[data-count="4"] .fb-featured-media-grid__item:nth-child(4) {
+      grid-column: 4 / span 3;
+      grid-row: 2;
+    }
+    .fb-featured-media-grid__item img {
       width: 100%;
       height: 100%;
-      object-fit: contain;
-      background: #000;
+      object-fit: cover;
+      display: block;
     }
     .fb-media img {
       position: absolute;
@@ -472,35 +484,8 @@
       object-fit: cover;
       display: block;
     }
-    .fb-media--multi {
-      padding-top: 0;
-      display: grid;
-      grid-template-columns: repeat(2, 1fr);
-      grid-template-rows: repeat(2, 1fr);
-      gap: 2px;
-      background: #000;
-      aspect-ratio: 1;
-          justify-content: center !important;
-    align-items: center !important;
-    align-content: center !important;
-    justify-items: center !important;
-    }
-    .fb-card--featured .fb-media--multi {
-      aspect-ratio: 16 / 9;
+    .fb-card--featured .fb-media img {
       border-radius: 12px;
-    }
-    .fb-media--multi img {
-      position: static;
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-    }
-    .fb-media--multi img:first-child { border-top-left-radius: 12px; }
-    .fb-media--multi img:nth-child(2) { border-top-right-radius: 12px; }
-    .fb-media--multi img:nth-child(3) { border-bottom-left-radius: 12px; }
-    .fb-media--multi img:nth-child(4) { border-bottom-right-radius: 12px; }
-    .fb-media--multi--more img:nth-of-type(4) {
-      filter: brightness(0.6);
     }
     .fb-media__more {
       position: absolute;
@@ -516,8 +501,9 @@
       pointer-events: none;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
     }
-    .fb-card--featured .fb-media:not(.fb-media--multi) img {
-      border-radius: 12px;
+    .fb-featured-media-grid__item:last-child .fb-media__more {
+      right: 10px;
+      bottom: 10px;
     }
     .fb-body { padding: 12px 14px; }
     .fb-card--featured .fb-body {
@@ -537,29 +523,34 @@
       color: #1c1c1c;
     }
     .fb-text {
-      white-space: pre-wrap;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
       color: #111111;
       font-size: 0.98em;
       line-height: 1.35;
+    }
+    .fb-text__content {
+      white-space: pre-wrap;
       max-height: 6.5em;
       overflow: hidden;
     }
     .fb-card--featured .fb-text {
-      max-height: none;
       font-size: 1.05em;
       line-height: 1.45;
+      color: #1c1c1c;
     }
-    .fb-text--truncated {
+    .fb-card--featured .fb-text__content {
+      max-height: none;
+    }
+    .fb-text__content--truncated {
       position: relative;
-      overflow: hidden;
-    }
-    .fb-card--featured .fb-text--truncated {
-      max-height: 8.7em;
       display: -webkit-box;
       -webkit-box-orient: vertical;
       -webkit-line-clamp: 6;
+      overflow: hidden;
     }
-    .fb-text--truncated::after {
+    .fb-text__content--truncated::after {
       content: "";
       position: absolute;
       left: 0;
@@ -569,7 +560,15 @@
       background: linear-gradient(180deg, rgba(241, 241, 241, 0) 0%, #f1f1f1 85%);
       pointer-events: none;
     }
-    .fb-card--carousel .fb-text {
+    .fb-text__more {
+      font-size: 0.92em;
+      font-weight: 600;
+      color: #444;
+    }
+    .fb-card--featured .fb-text__more {
+      color: #1c1c1c;
+    }
+    .fb-card--carousel .fb-text__content {
       max-height: 5.4em;
     }
 


### PR DESCRIPTION
## Summary
- show the featured Facebook post as a static grid of up to five photos with an extra-count overlay instead of a slider
- display a "Kliknij i zobacz więcej" hint when the featured text is truncated and limit carousel cards to a single image
- refresh the Facebook feed styles to support the new grid layout and text blocks

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ca777123a48330808312ca27e9a30c