### PR TITLE
Adjust Facebook feed layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,10 +137,10 @@
 
   <div id="fb-feed" class="fb-feed">
     <div id="fb-featured" class="fb-featured" aria-live="polite"></div>
-    <div id="fb-carousel-window" class="fb-carousel-window" style="display:none;" tabindex="0">
-      <button id="fbBtnPrev" class="nav-btn left" aria-label="Pokaż wcześniejsze posty">&#9664;</button>
+    <div id="fb-carousel-window" class="fb-carousel-window" hidden tabindex="0">
+      <button id="fbBtnPrev" class="nav-btn left" aria-label="Przewiń do wcześniejszych postów">&#9650;</button>
       <div id="fb-carousel" class="fb-carousel"></div>
-      <button id="fbBtnNext" class="nav-btn right" aria-label="Pokaż kolejne posty">&#9654;</button>
+      <button id="fbBtnNext" class="nav-btn right" aria-label="Przewiń do kolejnych postów">&#9660;</button>
     </div>
   </div>
   <!-- ======== /Facebook: Najnowsze posty ======== -->
@@ -453,21 +453,21 @@
 
     function updateFbNav() {
       if (!fbCarousel || !fbBtnPrev || !fbBtnNext) return;
-      const canScroll = fbCarousel.scrollWidth > fbCarousel.clientWidth + 1;
+      const canScroll = fbCarousel.scrollHeight > fbCarousel.clientHeight + 1;
       if (!canScroll) {
         fbBtnPrev.style.display = "none";
         fbBtnNext.style.display = "none";
         return;
       }
 
-      fbBtnPrev.style.display = fbCarousel.scrollLeft > 0 ? "block" : "none";
-      const maxScrollLeft = fbCarousel.scrollWidth - fbCarousel.clientWidth - 1;
-      fbBtnNext.style.display = fbCarousel.scrollLeft < maxScrollLeft ? "block" : "none";
+      fbBtnPrev.style.display = fbCarousel.scrollTop > 0 ? "block" : "none";
+      const maxScrollTop = fbCarousel.scrollHeight - fbCarousel.clientHeight - 1;
+      fbBtnNext.style.display = fbCarousel.scrollTop < maxScrollTop ? "block" : "none";
     }
 
     function scrollFb(offset) {
       if (!fbCarousel) return;
-      fbCarousel.scrollBy({ left: offset, behavior: "smooth" });
+      fbCarousel.scrollBy({ top: offset, behavior: "smooth" });
     }
 
     async function loadFbFeed() {
@@ -501,20 +501,21 @@
 
         if (rest.length && fbCarousel && carouselWindow) {
           fbCarousel.innerHTML = rest.map(p => postCard(p, "carousel")).join("");
-          carouselWindow.style.display = "block";
+          fbCarousel.scrollTop = 0;
+          carouselWindow.hidden = false;
 
           if (!fbCarouselBound && fbBtnPrev && fbBtnNext) {
-            fbBtnPrev.addEventListener("click", () => scrollFb(-fbCarousel.clientWidth));
-            fbBtnNext.addEventListener("click", () => scrollFb(fbCarousel.clientWidth));
+            fbBtnPrev.addEventListener("click", () => scrollFb(-fbCarousel.clientHeight));
+            fbBtnNext.addEventListener("click", () => scrollFb(fbCarousel.clientHeight));
             fbCarousel.addEventListener("scroll", updateFbNav);
             if (carouselWindow) {
               carouselWindow.addEventListener("keydown", e => {
-                if (e.key === "ArrowLeft") {
+                if (e.key === "ArrowUp") {
                   e.preventDefault();
-                  scrollFb(-fbCarousel.clientWidth);
-                } else if (e.key === "ArrowRight") {
+                  scrollFb(-fbCarousel.clientHeight);
+                } else if (e.key === "ArrowDown") {
                   e.preventDefault();
-                  scrollFb(fbCarousel.clientWidth);
+                  scrollFb(fbCarousel.clientHeight);
                 }
               });
             }
@@ -528,7 +529,7 @@
           raf(updateFbNav);
         } else if (fbCarousel && carouselWindow) {
           fbCarousel.innerHTML = "";
-          carouselWindow.style.display = "none";
+          carouselWindow.hidden = true;
         }
 
         loader.style.display = "none";

--- a/style.css
+++ b/style.css
@@ -351,35 +351,75 @@
       max-width: 1200px;
       margin: 18px auto 40px;
       padding: 0 16px;
-      display: flex;
-      flex-direction: column;
+      display: grid;
+      grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
       gap: 28px;
+      align-items: start;
     }
     .fb-featured {
-      align-self: center;
+      align-self: stretch;
       width: 100%;
-      max-width: 600px;
+      max-width: none;
     }
     .fb-featured:empty {
       display: none;
     }
     .fb-carousel-window {
       position: relative;
+      display: flex;
+      flex-direction: column;
+      align-self: stretch;
       overflow: hidden;
+      max-height: 80vh;
+      min-height: 340px;
+      padding: 40px 0;
+    }
+    .fb-carousel-window[hidden] {
       display: none;
+    }
+    .fb-carousel-window .nav-btn {
+      left: 50%;
+      transform: translate(-50%, 0);
+      top: auto;
+      bottom: auto;
+      right: auto;
+      background: rgba(255, 255, 255, 0.92);
+      border-radius: 999px;
+      box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+    }
+    .fb-carousel-window .nav-btn.left {
+      top: 8px;
+      left: 50%;
+    }
+    .fb-carousel-window .nav-btn.right {
+      bottom: 8px;
+      left: 50%;
+      right: auto;
     }
     .fb-carousel-window:focus { outline: none; }
     .fb-carousel {
       display: flex;
-      gap: 18px;
-      overflow-x: auto;
+      flex-direction: column;
+      gap: 16px;
+      overflow-y: auto;
       scroll-behavior: smooth;
       align-items: stretch;
-      padding-bottom: 4px;
-      -ms-overflow-style: none;
-      scrollbar-width: none;
+      flex: 1 1 auto;
+      padding: 0 6px;
+      scrollbar-width: thin;
+      scrollbar-color: rgba(229, 9, 20, 0.55) rgba(255, 255, 255, 0.08);
     }
-    .fb-carousel::-webkit-scrollbar { display: none; }
+    .fb-carousel::-webkit-scrollbar {
+      width: 8px;
+    }
+    .fb-carousel::-webkit-scrollbar-track {
+      background: rgba(255, 255, 255, 0.08);
+      border-radius: 999px;
+    }
+    .fb-carousel::-webkit-scrollbar-thumb {
+      background: rgba(229, 9, 20, 0.55);
+      border-radius: 999px;
+    }
     .fb-card {
       background: #f1f1f1;
       border: 1px solid #2a2a2a;
@@ -401,8 +441,8 @@
       padding: 18px;
     }
     .fb-card--carousel {
-      flex: 0 0 300px;
-      width: 300px;
+      flex: 0 0 auto;
+      width: 100%;
     }
     .fb-media {
       position: relative;
@@ -573,6 +613,22 @@
     }
 
     @media (max-width: 1024px) {
+      .fb-feed {
+        grid-template-columns: 1fr;
+      }
+      .fb-carousel-window {
+        max-height: none;
+        min-height: 0;
+        padding: 0;
+      }
+      .fb-carousel {
+        max-height: none;
+        overflow-y: visible;
+        padding: 0;
+      }
+      .fb-carousel-window .nav-btn {
+        display: none !important;
+      }
       .fb-card--featured {
         grid-template-columns: 1fr;
       }
@@ -583,8 +639,8 @@
 
     @media (max-width: 600px) {
       .fb-card--carousel {
-        flex: 0 0 260px;
-        width: 260px;
+        flex: 0 0 auto;
+        width: 100%;
       }
     }
 


### PR DESCRIPTION
## Summary
- rework the Facebook feed markup so the featured entry stays on the left and supporting posts live in a scrollable column on the right
- update the feed loader script to drive vertical scrolling controls and keyboard navigation for the sidebar list
- refresh the feed styling to use a responsive grid layout with dedicated scrollbar styling and mobile fallbacks

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ca7d33c8dc8330b4692472cdfb8f65