### PR TITLE
Adjust Facebook feed layout and sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -377,6 +377,11 @@
     let fbBtnPrev = null;
     let fbBtnNext = null;
     let fbCarouselBound = false;
+    let fbCarouselWindowEl = null;
+    let fbFeaturedCardEl = null;
+    let fbLayoutResizeObserver = null;
+    let fbLayoutListenersBound = false;
+    const fbLayoutMediaQuery = window.matchMedia("(min-width: 1025px)");
 
     const esc = (s = "") => s.replaceAll("<", "&lt;");
 
@@ -399,6 +404,66 @@
       const d = new Date(iso); if (isNaN(d)) return "";
       return `${String(d.getDate()).padStart(2, "0")}.${String(d.getMonth() + 1).padStart(2, "0")}.${d.getFullYear()}`;
     };
+
+    function syncFbCarouselLayout() {
+      if (!fbCarousel || !fbCarouselWindowEl) return;
+      if (!fbLayoutMediaQuery.matches || fbCarouselWindowEl.hidden) {
+        fbCarouselWindowEl.style.removeProperty("--fb-featured-height");
+        fbCarousel.style.removeProperty("--fb-carousel-count");
+        return;
+      }
+
+      const itemsCount = fbCarousel.children.length;
+      if (itemsCount <= 0) {
+        fbCarouselWindowEl.style.removeProperty("--fb-featured-height");
+        fbCarousel.style.removeProperty("--fb-carousel-count");
+        return;
+      }
+
+      const featuredCard = fbFeaturedCardEl || document.getElementById("fb-featured")?.querySelector(".fb-card--featured");
+      if (!featuredCard) {
+        fbCarouselWindowEl.style.removeProperty("--fb-featured-height");
+        return;
+      }
+
+      const rect = featuredCard.getBoundingClientRect();
+      if (rect.height > 0) {
+        fbCarouselWindowEl.style.setProperty("--fb-featured-height", `${rect.height}px`);
+      }
+      fbCarousel.style.setProperty("--fb-carousel-count", String(itemsCount));
+    }
+
+    function onFbLayoutChange() {
+      syncFbCarouselLayout();
+    }
+
+    function ensureFbLayoutListeners() {
+      if (fbLayoutListenersBound) return;
+      window.addEventListener("resize", onFbLayoutChange);
+      if (typeof fbLayoutMediaQuery.addEventListener === "function") {
+        fbLayoutMediaQuery.addEventListener("change", onFbLayoutChange);
+      } else if (typeof fbLayoutMediaQuery.addListener === "function") {
+        fbLayoutMediaQuery.addListener(onFbLayoutChange);
+      }
+      fbLayoutListenersBound = true;
+    }
+
+    function bindFbLayoutObserver() {
+      if (!("ResizeObserver" in window)) {
+        return;
+      }
+      if (fbLayoutResizeObserver) {
+        fbLayoutResizeObserver.disconnect();
+        fbLayoutResizeObserver = null;
+      }
+      if (!fbFeaturedCardEl) {
+        return;
+      }
+      fbLayoutResizeObserver = new ResizeObserver(() => {
+        syncFbCarouselLayout();
+      });
+      fbLayoutResizeObserver.observe(fbFeaturedCardEl);
+    }
 
     const postCard = (p, variant = "grid") => {
       const media = Array.isArray(p.media) ? p.media.filter(m => m && m.src) : [];
@@ -478,6 +543,7 @@
       fbCarousel = document.getElementById("fb-carousel");
       fbBtnPrev = document.getElementById("fbBtnPrev");
       fbBtnNext = document.getElementById("fbBtnNext");
+      fbCarouselWindowEl = carouselWindow;
       try {
         const url = new URL(WORKER_URL);
         url.searchParams.set("page_id", FB_PAGE_ID);
@@ -499,10 +565,15 @@
           featured.style.display = "none";
         }
 
+        fbFeaturedCardEl = featured?.querySelector(".fb-card--featured") || null;
+        bindFbLayoutObserver();
+
         if (rest.length && fbCarousel && carouselWindow) {
           fbCarousel.innerHTML = rest.map(p => postCard(p, "carousel")).join("");
           fbCarousel.scrollTop = 0;
           carouselWindow.hidden = false;
+          ensureFbLayoutListeners();
+          syncFbCarouselLayout();
 
           if (!fbCarouselBound && fbBtnPrev && fbBtnNext) {
             fbBtnPrev.addEventListener("click", () => scrollFb(-fbCarousel.clientHeight));
@@ -526,10 +597,15 @@
           const raf = window.requestAnimationFrame
             ? window.requestAnimationFrame.bind(window)
             : fn => setTimeout(fn, 0);
-          raf(updateFbNav);
+          raf(() => {
+            updateFbNav();
+            syncFbCarouselLayout();
+          });
         } else if (fbCarousel && carouselWindow) {
           fbCarousel.innerHTML = "";
           carouselWindow.hidden = true;
+          fbCarousel.style.removeProperty("--fb-carousel-count");
+          carouselWindow.style.removeProperty("--fb-featured-height");
         }
 
         loader.style.display = "none";
@@ -537,6 +613,12 @@
         console.warn("FB feed error", e);
         loader.style.display = "none";
         fallback.style.display = "block";
+        if (fbCarouselWindowEl) {
+          fbCarouselWindowEl.style.removeProperty("--fb-featured-height");
+        }
+        if (fbCarousel) {
+          fbCarousel.style.removeProperty("--fb-carousel-count");
+        }
       }
     }
 

--- a/style.css
+++ b/style.css
@@ -354,12 +354,17 @@
       display: grid;
       grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
       gap: 28px;
-      align-items: start;
+      align-items: stretch;
     }
     .fb-featured {
       align-self: stretch;
       width: 100%;
       max-width: none;
+      display: flex;
+    }
+    .fb-featured > * {
+      flex: 1 1 auto;
+      height: 100%;
     }
     .fb-featured:empty {
       display: none;
@@ -370,55 +375,44 @@
       flex-direction: column;
       align-self: stretch;
       overflow: hidden;
-      max-height: 80vh;
-      min-height: 340px;
-      padding: 40px 0;
+      gap: 16px;
+      padding: 0;
+      max-height: none;
+      min-height: 0;
+      height: var(--fb-featured-height, auto);
     }
     .fb-carousel-window[hidden] {
       display: none;
     }
     .fb-carousel-window .nav-btn {
-      left: 50%;
-      transform: translate(-50%, 0);
-      top: auto;
+      left: auto;
+      right: 14px;
+      transform: none;
+      top: 12px;
       bottom: auto;
-      right: auto;
       background: rgba(255, 255, 255, 0.92);
       border-radius: 999px;
       box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
     }
     .fb-carousel-window .nav-btn.left {
-      top: 8px;
-      left: 50%;
+      top: 12px;
     }
     .fb-carousel-window .nav-btn.right {
-      bottom: 8px;
-      left: 50%;
-      right: auto;
+      top: auto;
+      bottom: 12px;
     }
     .fb-carousel-window:focus { outline: none; }
     .fb-carousel {
-      display: flex;
-      flex-direction: column;
+      display: grid;
+      grid-template-rows: repeat(var(--fb-carousel-count, 3), minmax(0, 1fr));
+      grid-auto-rows: minmax(0, 1fr);
       gap: 16px;
-      overflow-y: auto;
-      scroll-behavior: smooth;
-      align-items: stretch;
+      align-content: stretch;
+      justify-items: stretch;
       flex: 1 1 auto;
+      height: 100%;
       padding: 0 6px;
-      scrollbar-width: thin;
-      scrollbar-color: rgba(229, 9, 20, 0.55) rgba(255, 255, 255, 0.08);
-    }
-    .fb-carousel::-webkit-scrollbar {
-      width: 8px;
-    }
-    .fb-carousel::-webkit-scrollbar-track {
-      background: rgba(255, 255, 255, 0.08);
-      border-radius: 999px;
-    }
-    .fb-carousel::-webkit-scrollbar-thumb {
-      background: rgba(229, 9, 20, 0.55);
-      border-radius: 999px;
+      overflow: hidden;
     }
     .fb-card {
       background: #f1f1f1;
@@ -439,10 +433,21 @@
       grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
       gap: 24px;
       padding: 18px;
+      height: 100%;
     }
     .fb-card--carousel {
       flex: 0 0 auto;
       width: 100%;
+      height: 100%;
+    }
+    .fb-card--carousel .fb-body {
+      flex: 1 1 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    .fb-card--carousel .fb-text {
+      flex: 1 1 auto;
     }
     .fb-media {
       position: relative;
@@ -616,21 +621,36 @@
       .fb-feed {
         grid-template-columns: 1fr;
       }
+      .fb-featured {
+        display: block;
+      }
+      .fb-featured > * {
+        height: auto;
+      }
       .fb-carousel-window {
         max-height: none;
         min-height: 0;
         padding: 0;
+        gap: 16px;
+        height: auto;
       }
       .fb-carousel {
         max-height: none;
         overflow-y: visible;
         padding: 0;
+        display: flex;
+        flex-direction: column;
+        height: auto;
       }
       .fb-carousel-window .nav-btn {
         display: none !important;
       }
       .fb-card--featured {
         grid-template-columns: 1fr;
+        height: auto;
+      }
+      .fb-card--carousel {
+        height: auto;
       }
       .fb-card--featured .fb-body {
         padding-top: 12px;


### PR DESCRIPTION
## Summary
- align the featured Facebook post to stretch on the left column and present secondary posts in an evenly sized right column within the existing width limits
- update styles for the Facebook carousel to use a two-column layout with equal-height cards and responsive fallbacks for smaller screens
- enhance the Facebook feed script to synchronize column heights via CSS variables and a ResizeObserver, keeping the layout consistent while resizing

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca8365ecc88330a572187e5f3d2858