### PR TITLE
Rework Facebook feed layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
 
   <div id="fb-feed" class="fb-feed">
     <div id="fb-featured" class="fb-featured" aria-live="polite"></div>
-    <div id="fb-carousel-window" class="fb-carousel-window" style="display:none;" tabindex="0">
+    <div id="fb-carousel-window" class="fb-carousel-window" tabindex="0">
       <button id="fbBtnPrev" class="nav-btn left" aria-label="Pokaż wcześniejsze posty">&#9664;</button>
       <div id="fb-carousel" class="fb-carousel"></div>
       <button id="fbBtnNext" class="nav-btn right" aria-label="Pokaż kolejne posty">&#9654;</button>
@@ -374,9 +374,6 @@
     const FB_LIMIT   = 6;                   // ile postów pokazać
 
     let fbCarousel = null;
-    let fbBtnPrev = null;
-    let fbBtnNext = null;
-    let fbCarouselBound = false;
 
     const esc = (s = "") => s.replaceAll("<", "&lt;");
 
@@ -451,33 +448,12 @@
       `;
     };
 
-    function updateFbNav() {
-      if (!fbCarousel || !fbBtnPrev || !fbBtnNext) return;
-      const canScroll = fbCarousel.scrollWidth > fbCarousel.clientWidth + 1;
-      if (!canScroll) {
-        fbBtnPrev.style.display = "none";
-        fbBtnNext.style.display = "none";
-        return;
-      }
-
-      fbBtnPrev.style.display = fbCarousel.scrollLeft > 0 ? "block" : "none";
-      const maxScrollLeft = fbCarousel.scrollWidth - fbCarousel.clientWidth - 1;
-      fbBtnNext.style.display = fbCarousel.scrollLeft < maxScrollLeft ? "block" : "none";
-    }
-
-    function scrollFb(offset) {
-      if (!fbCarousel) return;
-      fbCarousel.scrollBy({ left: offset, behavior: "smooth" });
-    }
-
     async function loadFbFeed() {
       const loader = document.getElementById("fb-feed-loader");
       const fallback = document.getElementById("fb-feed-fallback");
       const featured = document.getElementById("fb-featured");
       const carouselWindow = document.getElementById("fb-carousel-window");
       fbCarousel = document.getElementById("fb-carousel");
-      fbBtnPrev = document.getElementById("fbBtnPrev");
-      fbBtnNext = document.getElementById("fbBtnNext");
       try {
         const url = new URL(WORKER_URL);
         url.searchParams.set("page_id", FB_PAGE_ID);
@@ -501,34 +477,8 @@
 
         if (rest.length && fbCarousel && carouselWindow) {
           fbCarousel.innerHTML = rest.map(p => postCard(p, "carousel")).join("");
-          carouselWindow.style.display = "block";
-
-          if (!fbCarouselBound && fbBtnPrev && fbBtnNext) {
-            fbBtnPrev.addEventListener("click", () => scrollFb(-fbCarousel.clientWidth));
-            fbBtnNext.addEventListener("click", () => scrollFb(fbCarousel.clientWidth));
-            fbCarousel.addEventListener("scroll", updateFbNav);
-            if (carouselWindow) {
-              carouselWindow.addEventListener("keydown", e => {
-                if (e.key === "ArrowLeft") {
-                  e.preventDefault();
-                  scrollFb(-fbCarousel.clientWidth);
-                } else if (e.key === "ArrowRight") {
-                  e.preventDefault();
-                  scrollFb(fbCarousel.clientWidth);
-                }
-              });
-            }
-            window.addEventListener("resize", updateFbNav);
-            fbCarouselBound = true;
-          }
-
-          const raf = window.requestAnimationFrame
-            ? window.requestAnimationFrame.bind(window)
-            : fn => setTimeout(fn, 0);
-          raf(updateFbNav);
         } else if (fbCarousel && carouselWindow) {
           fbCarousel.innerHTML = "";
-          carouselWindow.style.display = "none";
         }
 
         loader.style.display = "none";

--- a/style.css
+++ b/style.css
@@ -346,40 +346,42 @@
       border-radius: 10px; background: #e50914; color: #fff; text-decoration: none;
     }
 
-    /* Facebook feed */
+    /* === Facebook: układ 2-kolumnowy z pionowym przewijaniem prawej kolumny === */
     .fb-feed {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 360px;
+      gap: 18px;
+      align-items: stretch;
       max-width: 1200px;
       margin: 18px auto 40px;
       padding: 0 16px;
-      display: flex;
-      flex-direction: column;
-      gap: 28px;
     }
     .fb-featured {
-      align-self: center;
+      max-width: none;
+      align-self: start;
       width: 100%;
-      max-width: 600px;
     }
     .fb-featured:empty {
       display: none;
     }
     .fb-carousel-window {
-      position: relative;
-      overflow: hidden;
-      display: none;
+      display: block !important;
+      min-height: 0;
+      align-self: stretch;
+      width: 100%;
     }
     .fb-carousel-window:focus { outline: none; }
     .fb-carousel {
       display: flex;
-      gap: 18px;
-      overflow-x: auto;
-      scroll-behavior: smooth;
-      align-items: stretch;
-      padding-bottom: 4px;
-      -ms-overflow-style: none;
-      scrollbar-width: none;
+      flex-direction: column;
+      gap: 12px;
+      height: 100%;
+      overflow-y: auto;
+      overflow-x: hidden;
+      padding-bottom: 0;
+      -ms-overflow-style: auto;
+      scrollbar-width: thin;
     }
-    .fb-carousel::-webkit-scrollbar { display: none; }
     .fb-card {
       background: #f1f1f1;
       border: 1px solid #2a2a2a;
@@ -401,8 +403,8 @@
       padding: 18px;
     }
     .fb-card--carousel {
-      flex: 0 0 300px;
-      width: 300px;
+      width: 100%;
+      flex: 0 0 auto;
     }
     .fb-media {
       position: relative;
@@ -572,19 +574,25 @@
       max-height: 5.4em;
     }
 
+    .fb-carousel-window .nav-btn { display: none !important; }
+
+    /* Na mniejszych ekranach wracamy do układu pod sobą */
+    @media (max-width: 900px) {
+      .fb-feed {
+        display: flex;
+        flex-direction: column;
+      }
+      .fb-carousel {
+        max-height: none;
+        overflow: visible;
+      }
+    }
     @media (max-width: 1024px) {
       .fb-card--featured {
         grid-template-columns: 1fr;
       }
       .fb-card--featured .fb-body {
         padding-top: 12px;
-      }
-    }
-
-    @media (max-width: 600px) {
-      .fb-card--carousel {
-        flex: 0 0 260px;
-        width: 260px;
       }
     }
 


### PR DESCRIPTION
## Summary
- switch the Facebook feed container to a two-column grid with a scrollable sidebar
- adapt carousel cards to stack vertically, hide the navigation arrows, and keep responsive fallbacks
- simplify the Facebook feed script now that carousel navigation is no longer used

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ca9ad000288330994baa32dc2eed74