### PR TITLE
Adjust Facebook feed layout and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,6 +374,28 @@
     const FB_LIMIT   = 6;                   // ile postów pokazać
 
     let fbCarousel = null;
+    let fbBtnPrev = null;
+    let fbBtnNext = null;
+    let carouselWindow = null;
+    let fbCarouselBound = false;
+
+    function updateFbNav() {
+      if (!fbCarousel || !fbBtnPrev || !fbBtnNext) return;
+      const canScroll = fbCarousel.scrollHeight > fbCarousel.clientHeight + 1;
+      if (!canScroll) {
+        fbBtnPrev.style.display = "none";
+        fbBtnNext.style.display = "none";
+        return;
+      }
+      fbBtnPrev.style.display = fbCarousel.scrollTop > 0 ? "flex" : "none";
+      const maxScrollTop = fbCarousel.scrollHeight - fbCarousel.clientHeight - 1;
+      fbBtnNext.style.display = fbCarousel.scrollTop < maxScrollTop ? "flex" : "none";
+    }
+
+    function scrollFb(offset) {
+      if (!fbCarousel) return;
+      fbCarousel.scrollBy({ top: offset, behavior: "smooth" });
+    }
 
     const esc = (s = "") => s.replaceAll("<", "&lt;");
 
@@ -452,8 +474,37 @@
       const loader = document.getElementById("fb-feed-loader");
       const fallback = document.getElementById("fb-feed-fallback");
       const featured = document.getElementById("fb-featured");
-      const carouselWindow = document.getElementById("fb-carousel-window");
+      carouselWindow = document.getElementById("fb-carousel-window");
       fbCarousel = document.getElementById("fb-carousel");
+      fbBtnPrev = document.getElementById("fbBtnPrev");
+      fbBtnNext = document.getElementById("fbBtnNext");
+
+      if (!fbCarouselBound && fbCarousel && fbBtnPrev && fbBtnNext) {
+        fbCarouselBound = true;
+
+        // strzałki – skok o wysokość widocznej części listy
+        fbBtnPrev.addEventListener("click", () => scrollFb(-fbCarousel.clientHeight));
+        fbBtnNext.addEventListener("click", () => scrollFb(fbCarousel.clientHeight));
+
+        fbCarousel.addEventListener("scroll", updateFbNav);
+
+        if (carouselWindow) {
+          carouselWindow.addEventListener("keydown", e => {
+            if (e.key === "ArrowUp") {
+              e.preventDefault();
+              scrollFb(-fbCarousel.clientHeight);
+            } else if (e.key === "ArrowDown") {
+              e.preventDefault();
+              scrollFb(fbCarousel.clientHeight);
+            }
+          });
+        }
+        window.addEventListener("resize", updateFbNav);
+
+        // (opcjonalnie) podmień wygląd strzałek na ▲ / ▼
+        if (fbBtnPrev) { fbBtnPrev.setAttribute("aria-label","Przewiń w górę"); fbBtnPrev.textContent = "▲"; }
+        if (fbBtnNext) { fbBtnNext.setAttribute("aria-label","Przewiń w dół");  fbBtnNext.textContent = "▼"; }
+      }
       try {
         const url = new URL(WORKER_URL);
         url.searchParams.set("page_id", FB_PAGE_ID);
@@ -482,10 +533,12 @@
         }
 
         loader.style.display = "none";
+        updateFbNav();
       } catch (e) {
         console.warn("FB feed error", e);
         loader.style.display = "none";
         fallback.style.display = "block";
+        updateFbNav();
       }
     }
 

--- a/style.css
+++ b/style.css
@@ -346,42 +346,51 @@
       border-radius: 10px; background: #e50914; color: #fff; text-decoration: none;
     }
 
-    /* === Facebook: układ 2-kolumnowy z pionowym przewijaniem prawej kolumny === */
-    .fb-feed {
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) 360px;
-      gap: 18px;
-      align-items: stretch;
-      max-width: 1200px;
-      margin: 18px auto 40px;
-      padding: 0 16px;
+    /* === Facebook: 2 kolumny: lewa featured, prawa przewijana pionowo === */
+    .fb-feed{
+      display:grid;
+      grid-template-columns:minmax(0,1fr) 340px; /* szer. prawej: zmień np. na 360px, 320px */
+      gap:18px;
+      align-items:stretch;
+      max-width:1200px;
+      margin:18px auto 40px;
+      padding:0 16px;
     }
-    .fb-featured {
-      max-width: none;
-      align-self: start;
-      width: 100%;
+
+    .fb-featured{
+      align-self:start;
+      max-width:none;   /* ważne – nie ograniczaj lewego */
+      width:100%;
     }
+
     .fb-featured:empty {
       display: none;
     }
-    .fb-carousel-window {
-      display: block !important;
-      min-height: 0;
-      align-self: stretch;
-      width: 100%;
+
+    /* Okno prawej kolumny ma mieć dokładnie wysokość lewej (grid to zapewnia) */
+    .fb-carousel-window{
+      position:relative;
+      display:block !important;
+      overflow:hidden; /* w środku przewija tylko lista */
+      min-height:0;    /* klucz w gridzie żeby overflow działał */
+      align-self:stretch;
     }
+
     .fb-carousel-window:focus { outline: none; }
-    .fb-carousel {
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-      height: 100%;
-      overflow-y: auto;
-      overflow-x: hidden;
-      padding-bottom: 0;
-      -ms-overflow-style: auto;
-      scrollbar-width: thin;
+
+    /* Z poziomej karuzeli robimy pionową listę z przewijaniem */
+    .fb-carousel{
+      display:flex;
+      flex-direction:column;
+      gap:12px;
+      height:100%;
+      overflow-y:auto;   /* przewijanie góra/dół */
+      overflow-x:hidden;
+      padding-bottom:0;
+      -ms-overflow-style:auto;
+      scrollbar-width:thin;
     }
+
     .fb-card {
       background: #f1f1f1;
       border: 1px solid #2a2a2a;
@@ -402,9 +411,33 @@
       gap: 24px;
       padding: 18px;
     }
-    .fb-card--carousel {
-      width: 100%;
-      flex: 0 0 auto;
+    /* Małe karty dopasowane do prawej kolumny */
+    .fb-card--carousel{
+      width:100%;
+      flex:0 0 auto;
+    }
+
+    /* Strzałki: zamieniamy na góra/dół i przypinamy do krawędzi */
+    #fbBtnPrev, #fbBtnNext{
+      position:absolute;
+      left:50%;
+      transform:translateX(-50%);
+      z-index:2;
+      width:36px; height:36px;
+      border-radius:999px;
+      border:0;
+      background:rgba(0,0,0,.65);
+      color:#fff;
+      display:none;
+      padding:0;
+      align-items:center; justify-content:center;
+      cursor:pointer;
+      user-select:none;
+    }
+    #fbBtnPrev{ top:8px; }
+    #fbBtnNext{ bottom:8px; }
+    #fbBtnPrev:focus-visible, #fbBtnNext:focus-visible{
+      outline:2px solid #e50914; outline-offset:2px;
     }
     .fb-media {
       position: relative;
@@ -573,19 +606,12 @@
     .fb-card--carousel .fb-text__content {
       max-height: 5.4em;
     }
-
-    .fb-carousel-window .nav-btn { display: none !important; }
-
-    /* Na mniejszych ekranach wracamy do układu pod sobą */
-    @media (max-width: 900px) {
-      .fb-feed {
-        display: flex;
-        flex-direction: column;
-      }
-      .fb-carousel {
-        max-height: none;
-        overflow: visible;
-      }
+    /* Na mniejszych ekranach wracamy pod sobą – bez przewijania */
+    @media (max-width: 900px){
+      .fb-feed{ display:flex; flex-direction:column; }
+      .fb-carousel-window{ height:auto; }
+      .fb-carousel{ max-height:none; overflow:visible; }
+      #fbBtnPrev, #fbBtnNext{ display:none !important; }
     }
     @media (max-width: 1024px) {
       .fb-card--featured {


### PR DESCRIPTION
## Summary
- restyle the Facebook feed into a two-column layout with a scrollable secondary column and vertical arrow controls
- update the Facebook navigation logic to scroll vertically, toggle button visibility, and support keyboard input

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68caa01fe17c83308d15828a4c81b8c8