### PR TITLE
Switch Facebook feed to vertical layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -388,13 +388,32 @@
         return;
       }
       fbBtnPrev.style.display = fbCarousel.scrollTop > 0 ? "flex" : "none";
-      const maxScrollTop = fbCarousel.scrollHeight - fbCarousel.clientHeight - 1;
-      fbBtnNext.style.display = fbCarousel.scrollTop < maxScrollTop ? "flex" : "none";
+      const maxTop = fbCarousel.scrollHeight - fbCarousel.clientHeight - 1;
+      fbBtnNext.style.display = fbCarousel.scrollTop < maxTop ? "flex" : "none";
     }
 
     function scrollFb(offset) {
       if (!fbCarousel) return;
       fbCarousel.scrollBy({ top: offset, behavior: "smooth" });
+    }
+
+    function syncCarouselHeight() {
+      const featured = document.getElementById("fb-featured");
+      const win = document.getElementById("fb-carousel-window");
+      if (!featured || !win) return;
+      win.style.height = featured.offsetHeight + "px"; // prawa = dokładnie lewa
+      updateFbNav();
+    }
+
+    let fbRo;
+    function afterFbRendered() {
+      syncCarouselHeight();
+      // aktualizacja przy zmianie rozmiaru lewej karty
+      if (window.ResizeObserver && !fbRo) {
+        fbRo = new ResizeObserver(syncCarouselHeight);
+        fbRo.observe(document.getElementById("fb-featured"));
+      }
+      window.addEventListener("resize", syncCarouselHeight);
     }
 
     const esc = (s = "") => s.replaceAll("<", "&lt;");
@@ -482,26 +501,21 @@
       if (!fbCarouselBound && fbCarousel && fbBtnPrev && fbBtnNext) {
         fbCarouselBound = true;
 
-        // strzałki – skok o wysokość widocznej części listy
+        // skok o wysokość widocznego okna listy
         fbBtnPrev.addEventListener("click", () => scrollFb(-fbCarousel.clientHeight));
-        fbBtnNext.addEventListener("click", () => scrollFb(fbCarousel.clientHeight));
+        fbBtnNext.addEventListener("click", () => scrollFb( fbCarousel.clientHeight));
 
         fbCarousel.addEventListener("scroll", updateFbNav);
 
         if (carouselWindow) {
           carouselWindow.addEventListener("keydown", e => {
-            if (e.key === "ArrowUp") {
-              e.preventDefault();
-              scrollFb(-fbCarousel.clientHeight);
-            } else if (e.key === "ArrowDown") {
-              e.preventDefault();
-              scrollFb(fbCarousel.clientHeight);
-            }
+            if (e.key === "ArrowUp")   { e.preventDefault(); scrollFb(-fbCarousel.clientHeight); }
+            if (e.key === "ArrowDown") { e.preventDefault(); scrollFb( fbCarousel.clientHeight); }
           });
         }
         window.addEventListener("resize", updateFbNav);
 
-        // (opcjonalnie) podmień wygląd strzałek na ▲ / ▼
+        // wygląd strzałek: ▲ / ▼
         if (fbBtnPrev) { fbBtnPrev.setAttribute("aria-label","Przewiń w górę"); fbBtnPrev.textContent = "▲"; }
         if (fbBtnNext) { fbBtnNext.setAttribute("aria-label","Przewiń w dół");  fbBtnNext.textContent = "▼"; }
       }
@@ -532,12 +546,21 @@
           fbCarousel.innerHTML = "";
         }
 
+        if (carouselWindow) {
+          carouselWindow.style.display = rest.length ? "block" : "none";
+        }
+
+        afterFbRendered();
+
         loader.style.display = "none";
         updateFbNav();
       } catch (e) {
         console.warn("FB feed error", e);
         loader.style.display = "none";
         fallback.style.display = "block";
+        if (carouselWindow) {
+          carouselWindow.style.display = "none";
+        }
         updateFbNav();
       }
     }

--- a/style.css
+++ b/style.css
@@ -346,10 +346,10 @@
       border-radius: 10px; background: #e50914; color: #fff; text-decoration: none;
     }
 
-    /* === Facebook: 2 kolumny: lewa featured, prawa przewijana pionowo === */
+    /* === Facebook: lewa featured, po prawej pionowy karuzel === */
     .fb-feed{
       display:grid;
-      grid-template-columns:minmax(0,1fr) 340px; /* szer. prawej: zmień np. na 360px, 320px */
+      grid-template-columns:minmax(0,1fr) 340px; /* zmień np. na 360/320 px */
       gap:18px;
       align-items:stretch;
       max-width:1200px;
@@ -359,37 +359,60 @@
 
     .fb-featured{
       align-self:start;
-      max-width:none;   /* ważne – nie ograniczaj lewego */
+      max-width:none;
       width:100%;
+    }
+
+    /* okno prawej kolumny = dokładnie wysokość lewej (resztę przewija w środku) */
+    .fb-carousel-window{
+      position:relative;
+      display:block !important;
+      overflow:hidden;   /* przewija tylko wnętrze */
+      min-height:0;      /* ważne dla grida, żeby overflow działał */
+      align-self:stretch;
+    }
+
+    /* pionowa lista kart */
+    .fb-carousel{
+      display:flex;
+      flex-direction:column;
+      gap:12px;
+      height:100%;
+      overflow-y:auto;         /* przewijanie góra/dół */
+      overflow-x:hidden;
+      padding-bottom:0;
+      -ms-overflow-style:auto;
+      scrollbar-width:thin;
+      overscroll-behavior:contain;
+      touch-action: pan-y;     /* swajp palcem na tel. */
+    }
+
+    /* małe karty dopasowane do szerokości prawej kolumny */
+    .fb-card--carousel{ width:100%; flex:0 0 auto; }
+
+    /* strzałki – wersja pionowa */
+    #fbBtnPrev,#fbBtnNext{
+      position:absolute;
+      left:50%;
+      transform:translateX(-50%);
+      z-index:2;
+      width:36px;height:36px;
+      border-radius:999px;border:0;
+      background:rgba(0,0,0,.65);color:#fff;
+      display:none;align-items:center;justify-content:center;
+      cursor:pointer;user-select:none;
+    }
+    #fbBtnPrev{ top:8px; }
+    #fbBtnNext{ bottom:8px; }
+    #fbBtnPrev:focus-visible,#fbBtnNext:focus-visible{
+      outline:2px solid #e50914; outline-offset:2px;
     }
 
     .fb-featured:empty {
       display: none;
     }
 
-    /* Okno prawej kolumny ma mieć dokładnie wysokość lewej (grid to zapewnia) */
-    .fb-carousel-window{
-      position:relative;
-      display:block !important;
-      overflow:hidden; /* w środku przewija tylko lista */
-      min-height:0;    /* klucz w gridzie żeby overflow działał */
-      align-self:stretch;
-    }
-
     .fb-carousel-window:focus { outline: none; }
-
-    /* Z poziomej karuzeli robimy pionową listę z przewijaniem */
-    .fb-carousel{
-      display:flex;
-      flex-direction:column;
-      gap:12px;
-      height:100%;
-      overflow-y:auto;   /* przewijanie góra/dół */
-      overflow-x:hidden;
-      padding-bottom:0;
-      -ms-overflow-style:auto;
-      scrollbar-width:thin;
-    }
 
     .fb-card {
       background: #f1f1f1;
@@ -410,34 +433,6 @@
       grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
       gap: 24px;
       padding: 18px;
-    }
-    /* Małe karty dopasowane do prawej kolumny */
-    .fb-card--carousel{
-      width:100%;
-      flex:0 0 auto;
-    }
-
-    /* Strzałki: zamieniamy na góra/dół i przypinamy do krawędzi */
-    #fbBtnPrev, #fbBtnNext{
-      position:absolute;
-      left:50%;
-      transform:translateX(-50%);
-      z-index:2;
-      width:36px; height:36px;
-      border-radius:999px;
-      border:0;
-      background:rgba(0,0,0,.65);
-      color:#fff;
-      display:none;
-      padding:0;
-      align-items:center; justify-content:center;
-      cursor:pointer;
-      user-select:none;
-    }
-    #fbBtnPrev{ top:8px; }
-    #fbBtnNext{ bottom:8px; }
-    #fbBtnPrev:focus-visible, #fbBtnNext:focus-visible{
-      outline:2px solid #e50914; outline-offset:2px;
     }
     .fb-media {
       position: relative;
@@ -606,12 +601,12 @@
     .fb-card--carousel .fb-text__content {
       max-height: 5.4em;
     }
-    /* Na mniejszych ekranach wracamy pod sobą – bez przewijania */
-    @media (max-width: 900px){
+    /* Mobile: jedna kolumna, naturalna wysokość, bez strzałek */
+    @media (max-width:900px){
       .fb-feed{ display:flex; flex-direction:column; }
-      .fb-carousel-window{ height:auto; }
+      .fb-carousel-window{ height:auto !important; }
       .fb-carousel{ max-height:none; overflow:visible; }
-      #fbBtnPrev, #fbBtnNext{ display:none !important; }
+      #fbBtnPrev,#fbBtnNext{ display:none !important; }
     }
     @media (max-width: 1024px) {
       .fb-card--featured {


### PR DESCRIPTION
## Summary
- restyle the Facebook feed grid to place the featured post left and a scrollable vertical carousel on the right, with mobile adjustments
- update navigation behavior, scrolling, and keyboard handling for the vertical carousel while syncing arrow labels
- add height synchronization and ResizeObserver logic so the carousel column always matches the featured post

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cb2ba0bd4c83309de589653a11dcfd