### PR TITLE
Adjust carousel navigation buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -627,9 +627,9 @@
 
     function updateNav() {
       if (!btnPrev || !btnNext || !playlist) return;
-      btnPrev.style.display = playlist.scrollLeft > 0 ? "block" : "none";
+      btnPrev.style.display = playlist.scrollLeft > 0 ? "flex" : "none";
       btnNext.style.display =
-        playlist.scrollLeft + playlist.clientWidth < playlist.scrollWidth ? "block" : "none";
+        playlist.scrollLeft + playlist.clientWidth < playlist.scrollWidth ? "flex" : "none";
     }
 
     async function fetchAllPlaylistItems(playlistId) {

--- a/style.css
+++ b/style.css
@@ -273,15 +273,31 @@
     .nav-btn {
       display: none;
       position: absolute;
-      top: 50%;
-      transform: translateY(-50%);
-        background: rgb(255, 255, 255);
-    border: none;
-    color: #0f0f0f;
-      padding: 8px 12px;
+      z-index: 2;
+      width: 36px;
+      height: 36px;
+      border-radius: 999px;
+      border: 0;
+      background: rgba(0, 0, 0, 0.65);
+      color: #fff;
       cursor: pointer;
       font-size: 1.2em;
-      z-index: 1;
+      line-height: 1;
+      align-items: center;
+      justify-content: center;
+      transition: background 0.2s ease;
+      user-select: none;
+    }
+    .nav-btn:hover {
+      background: rgba(0, 0, 0, 0.8);
+    }
+    .nav-btn:focus-visible {
+      outline: 2px solid #e50914;
+      outline-offset: 2px;
+    }
+    .playlist-window .nav-btn {
+      top: 50%;
+      transform: translateY(-50%);
     }
     .nav-btn.left { left: 0; }
     .nav-btn.right { right: 0; }
@@ -391,21 +407,18 @@
     .fb-card--carousel{ width:100%; flex:0 0 auto; }
 
     /* strzałki – wersja pionowa */
-    #fbBtnPrev,#fbBtnNext{
-      position:absolute;
-      left:50%;
-      transform:translateX(-50%);
-      z-index:2;
-      width:36px;height:36px;
-      border-radius:999px;border:0;
-      background:rgba(0,0,0,.65);color:#fff;
-      display:none;align-items:center;justify-content:center;
-      cursor:pointer;user-select:none;
+    .fb-carousel-window .nav-btn {
+      left: 50%;
+      transform: translateX(-50%);
+      user-select: none;
     }
-    #fbBtnPrev{ top:8px; }
-    #fbBtnNext{ bottom:8px; }
-    #fbBtnPrev:focus-visible,#fbBtnNext:focus-visible{
-      outline:2px solid #e50914; outline-offset:2px;
+    #fbBtnPrev {
+      top: 8px;
+      bottom: auto;
+    }
+    #fbBtnNext {
+      bottom: 8px;
+      top: auto;
     }
 
     .fb-featured:empty {


### PR DESCRIPTION
## Summary
- align Facebook carousel navigation so the down arrow sits at the bottom of the list
- restyle the shared navigation button class to reuse the circular dark theme used on the Facebook carousel and apply it to the YouTube playlist arrows
- update playlist navigation logic to show buttons as flex elements for proper centering inside the new styling

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cb35cff1e48330ab4a5c147b853a8e