### PR TITLE
Add animated rotating backgrounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,9 +37,124 @@
 
 
     <script>
-      document.addEventListener('scroll', () => {
-        const y = window.scrollY * 0.2;
-        document.body.style.backgroundPosition = `center ${-y}px`;
+      document.addEventListener('DOMContentLoaded', () => {
+        const backgrounds = [
+          'backgrounds/background1.jpg',
+          'backgrounds/background2.jpg',
+          'backgrounds/background3.jpg',
+          'backgrounds/background4.jpg',
+          'backgrounds/background5.jpg',
+          'backgrounds/background6.jpg'
+        ];
+        const cycleDuration = 5000;
+        const rotator = document.createElement('div');
+        rotator.className = 'background-rotator';
+
+        const layers = [document.createElement('div'), document.createElement('div')];
+        layers.forEach((layer) => {
+          layer.className = 'background-rotator__image';
+          rotator.appendChild(layer);
+        });
+
+        document.body.prepend(rotator);
+
+        let activeIndex = 0;
+        let imageIndex = 0;
+        let moveRight = true;
+
+        const forceReflow = (element) => {
+          void element.offsetWidth;
+        };
+
+        const updateVerticalOffset = () => {
+          const offset = window.scrollY * 0.2;
+          const value = `calc(50% - ${offset}px)`;
+          layers.forEach((layer) => {
+            layer.style.backgroundPositionY = value;
+          });
+        };
+
+        const playPan = (layer, direction, includeFade) => {
+          const panName = direction === 'right' ? 'panRight' : 'panLeft';
+          const startX = direction === 'right' ? '40%' : '60%';
+          const finalX = direction === 'right' ? '60%' : '40%';
+
+          layer.dataset.direction = direction;
+          layer.dataset.finalX = finalX;
+          layer.style.zIndex = 2;
+          layer.style.backgroundPositionX = startX;
+          layer.style.animation = 'none';
+          forceReflow(layer);
+
+          const fadePart = includeFade ? 'fadeFromCorner var(--background-fade-duration) ease forwards, ' : '';
+          layer.style.animation = `${fadePart}${panName} var(--background-cycle-duration) ease-in-out forwards`;
+        };
+
+        const fadeOut = (layer) => {
+          if (!layer) {
+            return;
+          }
+
+          const finalX = layer.dataset.finalX || (layer.dataset.direction === 'right' ? '60%' : '40%');
+          if (finalX) {
+            layer.style.backgroundPositionX = finalX;
+          }
+
+          layer.style.zIndex = 1;
+          layer.style.animation = 'none';
+          forceReflow(layer);
+          layer.style.animation = 'fadeOut var(--background-fade-duration) ease forwards';
+        };
+
+        layers.forEach((layer) => {
+          layer.addEventListener('animationend', (event) => {
+            if (event.animationName === 'fadeOut') {
+              layer.style.opacity = 0;
+              layer.style.animation = '';
+              layer.style.zIndex = '';
+            }
+
+            if (event.animationName === 'fadeFromCorner') {
+              layer.style.opacity = 1;
+            }
+
+            if (event.animationName === 'panRight') {
+              layer.dataset.finalX = '60%';
+              layer.style.backgroundPositionX = '60%';
+            }
+
+            if (event.animationName === 'panLeft') {
+              layer.dataset.finalX = '40%';
+              layer.style.backgroundPositionX = '40%';
+            }
+          });
+        });
+
+        const showInitial = () => {
+          const layer = layers[activeIndex];
+          layer.style.backgroundImage = `url('${backgrounds[imageIndex]}')`;
+          playPan(layer, moveRight ? 'right' : 'left', true);
+          updateVerticalOffset();
+          moveRight = !moveRight;
+        };
+
+        const rotateBackground = () => {
+          const nextLayer = layers[1 - activeIndex];
+          imageIndex = (imageIndex + 1) % backgrounds.length;
+          nextLayer.style.backgroundImage = `url('${backgrounds[imageIndex]}')`;
+          playPan(nextLayer, moveRight ? 'right' : 'left', true);
+          updateVerticalOffset();
+
+          const currentLayer = layers[activeIndex];
+          fadeOut(currentLayer);
+
+          activeIndex = 1 - activeIndex;
+          moveRight = !moveRight;
+        };
+
+        showInitial();
+        setInterval(rotateBackground, cycleDuration);
+        document.addEventListener('scroll', updateVerticalOffset, { passive: true });
       });
     </script>
   </head>

--- a/style.css
+++ b/style.css
@@ -14,15 +14,72 @@
       height: 100%;
       scroll-behavior: smooth;
     }
+   :root {
+      --background-cycle-duration: 5000ms;
+      --background-fade-duration: 1200ms;
+    }
    body {
       height: 100%;
       margin: 0;
-      background: #111 url('background.jpg') no-repeat center 0;
+      background: #111 url('backgrounds/background1.jpg') no-repeat center 0;
       background-size: 300% 300%;
       color: #fff;
       font-family: 'Base02', Arial, Helvetica, sans-serif;
       text-align: center;
       overflow-x: hidden;
+      position: relative;
+    }
+    .background-rotator {
+      position: fixed;
+      inset: 0;
+      z-index: -1;
+      pointer-events: none;
+      overflow: hidden;
+      background: #111;
+    }
+    .background-rotator__image {
+      position: absolute;
+      inset: 0;
+      background-repeat: no-repeat;
+      background-size: 300% 300%;
+      background-position: 50% 50%;
+      opacity: 0;
+      transform-origin: left bottom;
+      clip-path: circle(150% at 0% 100%);
+    }
+    @keyframes fadeFromCorner {
+      0% {
+        opacity: 0;
+        clip-path: circle(0% at 0% 100%);
+      }
+      100% {
+        opacity: 1;
+        clip-path: circle(150% at 0% 100%);
+      }
+    }
+    @keyframes fadeOut {
+      0% {
+        opacity: 1;
+      }
+      100% {
+        opacity: 0;
+      }
+    }
+    @keyframes panRight {
+      0% {
+        background-position-x: 40%;
+      }
+      100% {
+        background-position-x: 60%;
+      }
+    }
+    @keyframes panLeft {
+      0% {
+        background-position-x: 60%;
+      }
+      100% {
+        background-position-x: 40%;
+      }
     }
     h1,
     h2,


### PR DESCRIPTION
## Summary
- add a fixed background rotator layer with fade/pan keyframes and default background fallback
- rotate through the background images with alternating horizontal panning and a bottom-left fade effect

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb528b325c833081d8c4a0faaa4e04