### PR TITLE
Slow down rotating background and stabilize pan

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
           'backgrounds/background5.jpg',
           'backgrounds/background6.jpg'
         ];
-        const cycleDuration = 5000;
+        const cycleDuration = 12000;
         const rotator = document.createElement('div');
         rotator.className = 'background-rotator';
 
@@ -66,14 +66,6 @@
 
         const forceReflow = (element) => {
           void element.offsetWidth;
-        };
-
-        const updateVerticalOffset = () => {
-          const offset = window.scrollY * 0.2;
-          const value = `calc(50% - ${offset}px)`;
-          layers.forEach((layer) => {
-            layer.style.backgroundPositionY = value;
-          });
         };
 
         const playPan = (layer, direction, includeFade) => {
@@ -136,7 +128,6 @@
           const layer = layers[activeIndex];
           layer.style.backgroundImage = `url('${backgrounds[imageIndex]}')`;
           playPan(layer, moveRight ? 'right' : 'left', true);
-          updateVerticalOffset();
           moveRight = !moveRight;
         };
 
@@ -145,7 +136,6 @@
           imageIndex = (imageIndex + 1) % backgrounds.length;
           nextLayer.style.backgroundImage = `url('${backgrounds[imageIndex]}')`;
           playPan(nextLayer, moveRight ? 'right' : 'left', true);
-          updateVerticalOffset();
 
           const currentLayer = layers[activeIndex];
           fadeOut(currentLayer);
@@ -156,7 +146,6 @@
 
         showInitial();
         setInterval(rotateBackground, cycleDuration);
-        document.addEventListener('scroll', updateVerticalOffset, { passive: true });
       });
     </script>
   </head>

--- a/style.css
+++ b/style.css
@@ -15,14 +15,14 @@
       scroll-behavior: smooth;
     }
    :root {
-      --background-cycle-duration: 5000ms;
+      --background-cycle-duration: 12000ms;
       --background-fade-duration: 1200ms;
     }
    body {
       height: 100%;
       margin: 0;
-      background: #111 url('backgrounds/background1.jpg') no-repeat center 0;
-      background-size: 300% 300%;
+      background: #111 url('backgrounds/background1.jpg') no-repeat center center;
+      background-size: cover;
       color: #fff;
       font-family: 'Base02', Arial, Helvetica, sans-serif;
       text-align: center;
@@ -41,7 +41,7 @@
       position: absolute;
       inset: 0;
       background-repeat: no-repeat;
-      background-size: 300% 300%;
+      background-size: cover;
       background-position: 50% 50%;
       opacity: 0;
       transform-origin: left bottom;
@@ -67,18 +67,18 @@
     }
     @keyframes panRight {
       0% {
-        background-position-x: 47.5%;
+        background-position-x: 40%;
       }
       100% {
-        background-position-x: 52.5%;
+        background-position-x: 60%;
       }
     }
     @keyframes panLeft {
       0% {
-        background-position-x: 52.5%;
+        background-position-x: 60%;
       }
       100% {
-        background-position-x: 47.5%;
+        background-position-x: 40%;
       }
     }
     h1,


### PR DESCRIPTION
## Summary
- slow down the rotating background cycle and align the pan keyframes to eliminate the abrupt jump before transitions
- remove the scroll-driven vertical offset so the background no longer moves during page scrolling
- ensure all background layers keep their original aspect ratio by switching to cover sizing

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cbb9da99e08330a319b3a4ac7304e4