### PR TITLE
Adjust background scaling for panoramic panning

### DIFF
--- a/style.css
+++ b/style.css
@@ -22,7 +22,7 @@
       height: 100%;
       margin: 0;
       background: #111 url('backgrounds/background1.jpg') no-repeat center center;
-      background-size: cover;
+      background-size: 130% auto;
       color: #fff;
       font-family: 'Base02', Arial, Helvetica, sans-serif;
       text-align: center;
@@ -41,7 +41,7 @@
       position: absolute;
       inset: 0;
       background-repeat: no-repeat;
-      background-size: cover;
+      background-size: 130% auto;
       background-position: 50% 50%;
       opacity: 0;
       transform-origin: left bottom;


### PR DESCRIPTION
## Summary
- expand the body background image width to 130% to preserve aspect ratio while adding horizontal panning margin
- apply the same 130% width scaling to rotating background layers so the animation can sweep smoothly between 40% and 60%

## Testing
- browser_container.run_playwright_script (manual verification of panning)


------
https://chatgpt.com/codex/tasks/task_e_68cbc1d4ff34833092fc4899cbe3db2b