### PR TITLE
Update PWA manifest to use existing logo

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "ExploRide",
+  "short_name": "ExploRide",
+  "lang": "pl",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#111111",
+  "theme_color": "#111111",
+  "icons": [
+    {
+      "src": "/logo.png",
+      "sizes": "1080x1080",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a web app manifest so the icon entry points at `/logo.png` and describes its 1080×1080 metadata, replacing the removed standalone icon files

## Testing
- python -m json.tool manifest.json

------
https://chatgpt.com/codex/tasks/task_e_68cd41b946508330a905f50d788a2873