### PR TITLE
Przebudowa przełącznika sekcji wideo

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,6 +211,35 @@
           <div class="video-panel__inner">
             <div class="player-wrap">
               <h2>Najnowszy film</h2>
+              <div class="video-switcher__controls-slot">
+                <div
+                  class="video-switcher__controls"
+                  id="video-switcher-controls"
+                  role="tablist"
+                  aria-label="Wybierz kategorię filmów"
+                >
+                  <button
+                    class="video-toggle is-active"
+                    type="button"
+                    role="tab"
+                    data-video-target="urbex"
+                    aria-controls="urbex-section"
+                    aria-selected="true"
+                  >
+                    <span class="video-toggle__label">URBEX</span>
+                  </button>
+                  <button
+                    class="video-toggle"
+                    type="button"
+                    role="tab"
+                    data-video-target="travel"
+                    aria-controls="travel-section"
+                    aria-selected="false"
+                  >
+                    <span class="video-toggle__label">PODRÓŻE</span>
+                  </button>
+                </div>
+              </div>
               <div class="ratio">
                 <!-- Player playlisty (YouTube sam odtworzy najnowszy jako pierwszy) -->
                 <iframe
@@ -247,6 +276,7 @@
           <div class="video-panel__inner">
             <div class="player-wrap">
               <h2>Najnowszy film</h2>
+              <div class="video-switcher__controls-slot"></div>
               <div class="ratio">
                 <iframe
                   src="https://www.youtube.com/embed/videoseries?list=PL8VD37UX-sp35R-3mMPkhh4V6k63tWzvq"
@@ -280,15 +310,6 @@
         </section>
       </div>
     </div>
-    <button id="toggle-travel" class="video-toggle video-toggle--travel" type="button" aria-controls="travel-section" aria-expanded="false">
-      <span class="video-toggle__label">PODRÓŻE</span>
-      <span class="video-toggle__arrow" aria-hidden="true">&#9654;</span>
-    </button>
-    <button id="toggle-urbex" class="video-toggle video-toggle--urbex" type="button" aria-controls="urbex-section" aria-expanded="true">
-      <span class="video-toggle__arrow" aria-hidden="true">&#9664;</span>
-      <span class="video-toggle__label">URBEX</span>
-      
-    </button>
   </div>
 
     <hr class="divider" />
@@ -939,25 +960,57 @@
       const switcher = document.querySelector(".video-switcher");
       if (!switcher) return;
 
-      const toggleTravel = document.getElementById("toggle-travel");
-      const toggleUrbex = document.getElementById("toggle-urbex");
       const sections = {
         urbex: document.getElementById("urbex-section"),
         travel: document.getElementById("travel-section"),
       };
 
-      function showSection(name, focusTarget) {
-        if (name === "travel") {
-          switcher.classList.add("is-travel");
-          switcher.classList.remove("is-urbex");
-          toggleTravel?.setAttribute("aria-expanded", "true");
-          toggleUrbex?.setAttribute("aria-expanded", "false");
-        } else {
-          switcher.classList.add("is-urbex");
-          switcher.classList.remove("is-travel");
-          toggleTravel?.setAttribute("aria-expanded", "false");
-          toggleUrbex?.setAttribute("aria-expanded", "true");
+      const controls = document.getElementById("video-switcher-controls");
+      const toggleButtons = controls ? Array.from(controls.querySelectorAll("[data-video-target]")) : [];
+      const togglesByTarget = toggleButtons.reduce((acc, btn) => {
+        const target = btn?.dataset?.videoTarget;
+        if (!target) {
+          return acc;
         }
+        if (!acc[target]) {
+          acc[target] = [];
+        }
+        acc[target].push(btn);
+        return acc;
+      }, {});
+      const controlSlots = {
+        urbex: sections.urbex?.querySelector(".video-switcher__controls-slot"),
+        travel: sections.travel?.querySelector(".video-switcher__controls-slot"),
+      };
+
+      function updateUIForSection(name) {
+        const isTravel = name === "travel";
+        switcher.classList.toggle("is-travel", isTravel);
+        switcher.classList.toggle("is-urbex", !isTravel);
+
+        if (sections.travel) {
+          sections.travel.setAttribute("aria-hidden", isTravel ? "false" : "true");
+        }
+        if (sections.urbex) {
+          sections.urbex.setAttribute("aria-hidden", isTravel ? "true" : "false");
+        }
+
+        if (controls && controlSlots[name] && controls.parentElement !== controlSlots[name]) {
+          controlSlots[name].appendChild(controls);
+        }
+
+        Object.entries(togglesByTarget).forEach(([targetName, buttons]) => {
+          const isActive = targetName === name;
+          buttons.forEach((btn) => {
+            if (!btn) return;
+            btn.classList.toggle("is-active", isActive);
+            btn.setAttribute("aria-selected", isActive ? "true" : "false");
+          });
+        });
+      }
+
+      function showSection(name, focusTarget) {
+        updateUIForSection(name);
 
         const target = sections[name];
         if (focusTarget && target) {
@@ -969,8 +1022,12 @@
         }
       }
 
-      toggleTravel?.addEventListener("click", () => showSection("travel", true));
-      toggleUrbex?.addEventListener("click", () => showSection("urbex", true));
+      toggleButtons.forEach((btn) => {
+        btn.addEventListener("click", () => {
+          const target = btn.dataset.videoTarget === "travel" ? "travel" : "urbex";
+          showSection(target, true);
+        });
+      });
 
       showSection("urbex", false);
     }

--- a/style.css
+++ b/style.css
@@ -246,80 +246,85 @@
     }
     .video-panel__inner {
       padding: 0 clamp(28px, 6vw, 60px);
-      transition: padding 0.3s ease;
     }
-    .video-switcher.is-urbex .video-panel--urbex .video-panel__inner {
-      padding-right: clamp(90px, 12vw, 150px);
+    .video-switcher__controls-slot {
+      display: flex;
+      justify-content: center;
     }
-    .video-switcher.is-travel .video-panel--travel .video-panel__inner {
-      padding-left: clamp(90px, 12vw, 150px);
+    .video-switcher__controls {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      margin: 14px auto 0;
+      padding: 6px;
+      width: min(420px, 100%);
+      border-radius: 999px;
+      border: 1px solid rgba(229, 9, 20, 0.35);
+      background: linear-gradient(135deg, rgba(18, 18, 18, 0.92), rgba(32, 32, 32, 0.88));
+      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
     }
     .video-toggle {
-      position: absolute;
-      top: 35%;
-      transform: translateY(-50%);
-      background: #d9d9d9;
-      color: #000;
+      flex: 1 1 0;
+      min-width: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      padding: 12px 22px;
       border: 0;
-      border-radius: 20px;
-      padding: 20px 14px;
+      border-radius: 999px;
+      background: transparent;
+      color: #d5d5d5;
       font-family: 'BebasNeue', 'Base02', Arial, Helvetica, sans-serif;
-      font-size: 1.1em;
+      font-size: 1.05em;
       letter-spacing: 2px;
       text-transform: uppercase;
       cursor: pointer;
-      display: none;
-    
-      align-items: center;
-      justify-content: center;
-      gap: 12px;
-  
-      text-orientation: upright;
-      box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
-      transition: background 0.2s ease, box-shadow 0.2s ease;
+      transition: background 0.25s ease, color 0.25s ease, box-shadow 0.25s ease, transform 0.2s ease;
     }
+    .video-toggle__label { pointer-events: none; }
     .video-toggle:hover {
-      background: #f2f2f2;
-      box-shadow: 0 10px 26px rgba(0, 0, 0, 0.5);
+      color: #ffffff;
+    }
+    .video-toggle:hover:not(.is-active) {
+      background: rgba(229, 9, 20, 0.16);
+    }
+    .video-toggle.is-active {
+      background: linear-gradient(135deg, #e50914, #ff3b6a);
+      color: #ffffff;
+      box-shadow: 0 12px 26px rgba(229, 9, 20, 0.45);
+    }
+    .video-toggle:active {
+      transform: scale(0.97);
     }
     .video-toggle:focus-visible {
       outline: 3px solid #e50914;
-      outline-offset: 4px;
+      outline-offset: 3px;
     }
-    .video-toggle--travel { right: 0; }
-    .video-toggle--urbex { left: 0; }
-    .video-toggle__label,
-    .video-toggle__arrow {
-      pointer-events: none;
-    }
-    .video-toggle__arrow { font-size: 1.3em; }
-    .video-switcher.is-urbex #toggle-travel { display: flex; }
-    .video-switcher.is-urbex #toggle-urbex { display: none; }
-    .video-switcher.is-travel #toggle-travel { display: none; }
-    .video-switcher.is-travel #toggle-urbex { display: flex; }
     @media (max-width: 900px) {
       .video-toggle {
-        padding: 16px 12px;
+        padding: 10px 18px;
         font-size: 1em;
       }
     }
     @media (max-width: 720px) {
       .video-panel__inner { padding: 0 20px; }
-      .video-switcher.is-urbex .video-panel--urbex .video-panel__inner { padding-right: 80px; }
-      .video-switcher.is-travel .video-panel--travel .video-panel__inner { padding-left: 80px; }
-      .video-toggle {
-        top: auto;
-        bottom: 24px;
-        transform: none;
+      .video-switcher__controls {
+        margin: 14px auto 0;
+        padding: 6px 5px;
       }
     }
     @media (max-width: 520px) {
       .video-panel__inner { padding: 0 16px; }
-      .video-switcher.is-urbex .video-panel--urbex .video-panel__inner { padding-right: 64px; }
-      .video-switcher.is-travel .video-panel--travel .video-panel__inner { padding-left: 64px; }
+      .video-switcher__controls {
+        gap: 6px;
+      }
       .video-toggle {
-        padding: 14px 10px;
-        gap: 8px;
+        padding: 9px 14px;
+        letter-spacing: 1.5px;
       }
     }
     .ratio {


### PR DESCRIPTION
## Summary
- przeniosłem sterowanie playlistami Urbex/Podróże pod nagłówkiem „Najnowszy film” i przywróciłem niżej napis „Zobacz więcej filmów”
- przebudowałem logikę przełączania, aby przenosiła blok przycisków między sekcjami i odświeżała atrybuty dostępności
- nadałem przełącznikowi nowy wygląd: centralny pasek z gradientem, efektami hover/active i lepszym zachowaniem na małych ekranach

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd5653c6448330884063285fa7810d