### PR TITLE
Enable animated video panel slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -1027,6 +1027,8 @@
         return acc;
       }, {});
 
+      const sliders = Array.from(switcher.querySelectorAll(".video-switcher__slider"));
+
       function updateUIForSection(name) {
         const isTravel = name === "travel";
         switcher.classList.toggle("is-travel", isTravel);
@@ -1036,8 +1038,10 @@
           const isActive = targetName === name;
           panelList.forEach((panel) => {
             if (!panel) return;
-            panel.toggleAttribute("hidden", !isActive);
+            panel.removeAttribute("hidden");
             panel.setAttribute("aria-hidden", isActive ? "false" : "true");
+            panel.classList.toggle("is-active", isActive);
+            panel.classList.toggle("is-inactive", !isActive);
           });
         });
 
@@ -1049,6 +1053,12 @@
             btn.setAttribute("aria-selected", isActive ? "true" : "false");
             btn.setAttribute("aria-hidden", "false");
           });
+        });
+
+        const translateValue = isTravel ? "-100%" : "0%";
+        sliders.forEach((slider) => {
+          if (!slider) return;
+          slider.style.transform = `translateX(${translateValue})`;
         });
       }
 

--- a/style.css
+++ b/style.css
@@ -234,10 +234,22 @@
       overflow: hidden;
     }
     .video-switcher__slider {
-      display: block;
+      display: flex;
+      width: 100%;
+      transition: transform 400ms ease;
+      will-change: transform;
     }
     .video-panel {
+      flex: 0 0 100%;
       width: 100%;
+    }
+    .video-panel.is-active {
+      visibility: visible;
+      pointer-events: auto;
+    }
+    .video-panel.is-inactive {
+      visibility: hidden;
+      pointer-events: none;
     }
     .video-panel__inner {
       padding: 0 clamp(28px, 6vw, 60px);
@@ -256,9 +268,6 @@
       box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
       backdrop-filter: blur(6px);
       -webkit-backdrop-filter: blur(6px);
-    }
-    .video-panel[hidden] {
-      display: none;
     }
     .video-toggle {
       flex: 1 1 0;


### PR DESCRIPTION
## Summary
- lay out both video sliders as flex rows and add width/visibility states to panels for smooth transitions
- adjust playlist initializer to toggle aria states and slider transforms without using the hidden attribute

## Testing
- manual verification of video category toggle

------
https://chatgpt.com/codex/tasks/task_e_68cd6c77f07083308fa8881f31e2612b