### PR TITLE
Add collapsible mobile navigation menu

### DIFF
--- a/galeria.html
+++ b/galeria.html
@@ -6,6 +6,7 @@
   <title>Galeria – ExploRide</title>
   <link rel="icon" type="image/png" href="logo.png" />
   <link rel="stylesheet" href="style.css">
+  <script src="main.js" defer></script>
   <script>
     document.addEventListener('scroll', () => {
       const y = window.scrollY * 0.2;
@@ -19,7 +20,15 @@
       <img src="logo.png" alt="ExploRide logo" class="logo">
       <span class="brand-name">EXPLORIDE.PL</span>
     </a>
-    <nav class="top-nav" aria-label="Główna nawigacja">
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
+      <span class="nav-toggle__bars" aria-hidden="true">
+        <span></span>
+        <span></span>
+        <span></span>
+      </span>
+      <span class="nav-toggle__label">Menu</span>
+    </button>
+    <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
       <a class="nav-link nav-link--about" href="onas.html">O nas</a>
       <a class="nav-link nav-link--home" href="index.html#filmy">Filmy</a>
       <a class="nav-link nav-link--gallery" href="galeria.html" aria-current="page">Galeria</a>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="pl">
 <head>
   <link rel="stylesheet" href="style.css">
+  <script src="main.js" defer></script>
 
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -165,7 +166,15 @@
       <img src="logo.png" alt="ExploRide logo" class="logo">
       <span class="brand-name">EXPLORIDE.PL</span>
     </a>
-    <nav class="top-nav" aria-label="Główna nawigacja">
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
+      <span class="nav-toggle__bars" aria-hidden="true">
+        <span></span>
+        <span></span>
+        <span></span>
+      </span>
+      <span class="nav-toggle__label">Menu</span>
+    </button>
+    <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
       <a class="nav-link nav-link--about" href="onas.html">O nas</a>
       <a class="nav-link nav-link--home" href="#filmy">Filmy</a>
       <a class="nav-link nav-link--gallery" href="galeria.html">Galeria</a>

--- a/kontakt.html
+++ b/kontakt.html
@@ -6,6 +6,7 @@
   <title>Kontakt – ExploRide</title>
   <link rel="icon" type="image/png" href="logo.png" />
   <link rel="stylesheet" href="style.css">
+  <script src="main.js" defer></script>
   <script>
     document.addEventListener('scroll', () => {
       const y = window.scrollY * 0.2;
@@ -19,7 +20,15 @@
       <img src="logo.png" alt="ExploRide logo" class="logo">
       <span class="brand-name">EXPLORIDE.PL</span>
     </a>
-    <nav class="top-nav" aria-label="Główna nawigacja">
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
+      <span class="nav-toggle__bars" aria-hidden="true">
+        <span></span>
+        <span></span>
+        <span></span>
+      </span>
+      <span class="nav-toggle__label">Menu</span>
+    </button>
+    <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
       <a class="nav-link nav-link--about" href="onas.html">O nas</a>
       <a class="nav-link nav-link--home" href="index.html#filmy">Filmy</a>
       <a class="nav-link nav-link--gallery" href="galeria.html">Galeria</a>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,70 @@
+(function () {
+  function initNavToggle() {
+    const header = document.querySelector('header');
+    if (!header) {
+      return;
+    }
+
+    const toggle = header.querySelector('.nav-toggle');
+    const nav = header.querySelector('.top-nav');
+    if (!toggle || !nav) {
+      return;
+    }
+
+    const closeNav = () => {
+      header.classList.remove('is-nav-open');
+      toggle.setAttribute('aria-expanded', 'false');
+    };
+
+    const openNav = () => {
+      header.classList.add('is-nav-open');
+      toggle.setAttribute('aria-expanded', 'true');
+    };
+
+    const toggleNav = () => {
+      if (header.classList.contains('is-nav-open')) {
+        closeNav();
+      } else {
+        openNav();
+      }
+    };
+
+    toggle.addEventListener('click', toggleNav);
+
+    nav.addEventListener('click', (event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+      if (target.closest('a, button')) {
+        closeNav();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && header.classList.contains('is-nav-open')) {
+        closeNav();
+        toggle.focus();
+      }
+    });
+
+    const mediaQuery = window.matchMedia('(min-width: 768px)');
+    const handleMediaChange = (event) => {
+      if (event.matches) {
+        closeNav();
+      }
+    };
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handleMediaChange);
+    } else if (typeof mediaQuery.addListener === 'function') {
+      mediaQuery.addListener(handleMediaChange);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initNavToggle);
+  } else {
+    initNavToggle();
+  }
+})();

--- a/materialy.html
+++ b/materialy.html
@@ -6,6 +6,7 @@
   <title>Materiały do pobrania – ExploRide</title>
   <link rel="icon" type="image/png" href="logo.png" />
   <link rel="stylesheet" href="style.css">
+  <script src="main.js" defer></script>
   <script>
     document.addEventListener('scroll', () => {
       const y = window.scrollY * 0.2;
@@ -19,7 +20,15 @@
       <img src="logo.png" alt="ExploRide logo" class="logo">
       <span class="brand-name">EXPLORIDE.PL</span>
     </a>
-    <nav class="top-nav" aria-label="Główna nawigacja">
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
+      <span class="nav-toggle__bars" aria-hidden="true">
+        <span></span>
+        <span></span>
+        <span></span>
+      </span>
+      <span class="nav-toggle__label">Menu</span>
+    </button>
+    <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
       <a class="nav-link nav-link--about" href="onas.html">O nas</a>
       <a class="nav-link nav-link--home" href="index.html#filmy">Filmy</a>
       <a class="nav-link nav-link--gallery" href="galeria.html">Galeria</a>

--- a/onas.html
+++ b/onas.html
@@ -6,6 +6,7 @@
   <title>O nas – ExploRide</title>
   <link rel="icon" type="image/png" href="logo.png" />
   <link rel="stylesheet" href="style.css">
+  <script src="main.js" defer></script>
   <script>
     document.addEventListener('scroll', () => {
       const y = window.scrollY * 0.2;
@@ -19,7 +20,15 @@
       <img src="logo.png" alt="ExploRide logo" class="logo">
       <span class="brand-name">EXPLORIDE.PL</span>
     </a>
-    <nav class="top-nav" aria-label="Główna nawigacja">
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
+      <span class="nav-toggle__bars" aria-hidden="true">
+        <span></span>
+        <span></span>
+        <span></span>
+      </span>
+      <span class="nav-toggle__label">Menu</span>
+    </button>
+    <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
       <a class="nav-link nav-link--about" href="onas.html" aria-current="page">O nas</a>
       <a class="nav-link nav-link--home" href="index.html#filmy">Filmy</a>
       <a class="nav-link nav-link--gallery" href="galeria.html">Galeria</a>

--- a/style.css
+++ b/style.css
@@ -124,6 +124,56 @@
 }
 
     header .logo { height: 48px; }
+    .nav-toggle {
+      display: none;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 16px;
+      border-radius: 999px;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      background: rgba(255, 255, 255, 0.08);
+      color: #fff;
+      font-family: 'BebasNeue', 'Base02', Arial, Helvetica, sans-serif;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+      cursor: pointer;
+      transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+    }
+    .nav-toggle__bars {
+      display: inline-flex;
+      flex-direction: column;
+      gap: 5px;
+    }
+    .nav-toggle__bars span {
+      width: 22px;
+      height: 2px;
+      background: currentColor;
+      border-radius: 2px;
+      transition: transform 0.25s ease, opacity 0.25s ease;
+    }
+    .nav-toggle__label {
+      font-size: 0.9em;
+    }
+    .nav-toggle:hover,
+    .nav-toggle:focus-visible {
+      background: #e50914;
+      border-color: #e50914;
+      color: #fff;
+    }
+    header.is-nav-open .nav-toggle {
+      background: #e50914;
+      border-color: #e50914;
+      color: #fff;
+    }
+    header.is-nav-open .nav-toggle__bars span:nth-child(1) {
+      transform: translateY(7px) rotate(45deg);
+    }
+    header.is-nav-open .nav-toggle__bars span:nth-child(2) {
+      opacity: 0;
+    }
+    header.is-nav-open .nav-toggle__bars span:nth-child(3) {
+      transform: translateY(-7px) rotate(-45deg);
+    }
     .top-nav {
       display: flex;
       flex-wrap: wrap;
@@ -194,6 +244,33 @@
       background: rgba(255, 255, 255, 0.05);
       border-color: rgba(255, 255, 255, 0.08);
       color: #fff;
+    }
+    @media (max-width: 767px) {
+      header {
+        align-items: stretch;
+      }
+      .nav-toggle {
+        display: inline-flex;
+        align-self: flex-end;
+      }
+      .top-nav {
+        display: none;
+        flex-direction: column;
+        align-items: stretch;
+        width: 100%;
+        gap: 10px;
+        padding-top: 12px;
+        margin-top: 8px;
+        border-top: 1px solid rgba(255, 255, 255, 0.12);
+        background: transparent;
+      }
+      header.is-nav-open .top-nav {
+        display: flex;
+      }
+      .top-nav .nav-link {
+        justify-content: center;
+        width: 100%;
+      }
     }
     @media (min-width: 768px) {
       header {

--- a/wesprzyj-nas.html
+++ b/wesprzyj-nas.html
@@ -6,6 +6,7 @@
   <title>Wesprzyj nas – ExploRide</title>
   <link rel="icon" type="image/png" href="logo.png" />
   <link rel="stylesheet" href="style.css">
+  <script src="main.js" defer></script>
   <script>
     document.addEventListener('scroll', () => {
       const y = window.scrollY * 0.2;
@@ -19,7 +20,15 @@
       <img src="logo.png" alt="ExploRide logo" class="logo">
       <span class="brand-name">EXPLORIDE.PL</span>
     </a>
-    <nav class="top-nav" aria-label="Główna nawigacja">
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
+      <span class="nav-toggle__bars" aria-hidden="true">
+        <span></span>
+        <span></span>
+        <span></span>
+      </span>
+      <span class="nav-toggle__label">Menu</span>
+    </button>
+    <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
       <a class="nav-link nav-link--about" href="onas.html">O nas</a>
       <a class="nav-link nav-link--home" href="index.html#filmy">Filmy</a>
       <a class="nav-link nav-link--gallery" href="galeria.html">Galeria</a>


### PR DESCRIPTION
## Summary
- add a reusable navigation toggle script that collapses the header links on small screens
- update the global stylesheet with hamburger button styling and responsive menu layout
- include the toggle button and script reference across all main pages

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cda4ce44308330b52853fef73e4613