### PR TITLE
Przyspieszenie rozwijania mobilnego menu nawigacji

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,14 +11,41 @@
       return;
     }
 
+    const mediaQuery = window.matchMedia('(min-width: 768px)');
+
+    const isDesktop = () => mediaQuery.matches;
+
+    const updateNavHeight = () => {
+      if (isDesktop()) {
+        nav.style.removeProperty('--top-nav-expanded-height');
+        return;
+      }
+
+      const navHeight = nav.scrollHeight;
+      nav.style.setProperty('--top-nav-expanded-height', `${navHeight}px`);
+    };
+
+    const setNavAriaHidden = (hidden) => {
+      if (isDesktop()) {
+        nav.removeAttribute('aria-hidden');
+        return;
+      }
+
+      nav.setAttribute('aria-hidden', hidden ? 'true' : 'false');
+    };
+
     const closeNav = () => {
+      updateNavHeight();
       header.classList.remove('is-nav-open');
       toggle.setAttribute('aria-expanded', 'false');
+      setNavAriaHidden(true);
     };
 
     const openNav = () => {
+      updateNavHeight();
       header.classList.add('is-nav-open');
       toggle.setAttribute('aria-expanded', 'true');
+      setNavAriaHidden(false);
     };
 
     const toggleNav = () => {
@@ -48,10 +75,19 @@
       }
     });
 
-    const mediaQuery = window.matchMedia('(min-width: 768px)');
     const handleMediaChange = (event) => {
+      updateNavHeight();
+
       if (event.matches) {
         closeNav();
+      } else if (!header.classList.contains('is-nav-open')) {
+        setNavAriaHidden(true);
+      }
+    };
+
+    const handleResize = () => {
+      if (!isDesktop()) {
+        updateNavHeight();
       }
     };
 
@@ -59,6 +95,12 @@
       mediaQuery.addEventListener('change', handleMediaChange);
     } else if (typeof mediaQuery.addListener === 'function') {
       mediaQuery.addListener(handleMediaChange);
+    }
+    window.addEventListener('resize', handleResize);
+
+    updateNavHeight();
+    if (!isDesktop()) {
+      setNavAriaHidden(header.classList.contains('is-nav-open') ? false : true);
     }
   }
 

--- a/style.css
+++ b/style.css
@@ -254,7 +254,8 @@
         align-self: flex-end;
       }
       .top-nav {
-        display: none;
+        --top-nav-expanded-height: 75vh;
+        position: relative;
         flex-direction: column;
         align-items: stretch;
         width: 100%;
@@ -263,13 +264,33 @@
         margin-top: 8px;
         border-top: 1px solid rgba(255, 255, 255, 0.12);
         background: transparent;
+        overflow: hidden;
+        max-height: 0;
+        opacity: 0;
+        visibility: hidden;
+        pointer-events: none;
+        transform: translateY(-8px);
+        transition:
+          max-height 220ms cubic-bezier(0.4, 0, 0.2, 1),
+          opacity 140ms ease,
+          transform 200ms ease;
       }
       header.is-nav-open .top-nav {
-        display: flex;
+        max-height: var(--top-nav-expanded-height);
+        opacity: 1;
+        visibility: visible;
+        pointer-events: auto;
+        transform: translateY(0);
       }
       .top-nav .nav-link {
         justify-content: center;
         width: 100%;
+      }
+    }
+    @media (max-width: 767px) and (prefers-reduced-motion: reduce) {
+      .top-nav {
+        transition: none;
+        transform: none;
       }
     }
     @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- Zastąpiono ukrywanie mobilnej nawigacji zmianą `max-height`/opacity, aby usunąć opóźnienie po kliknięciu i dodać szybkie, płynne rozwijanie.
- Zaktualizowano logikę przełącznika w `main.js`, aby dynamicznie wyznaczać wysokość menu, pilnować atrybutów ARIA i reagować na zmianę szerokości ekranu.

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdab18815c8330a87af480d7a525c9