### PR TITLE
Simplify Facebook section to embed latest post

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,28 +359,12 @@
 
     <hr class="divider" />
 
-  <!-- ======== Facebook: Najnowsze posty ======== -->
+  <!-- ======== Facebook: Najnowszy post ======== -->
   <h2 id="posty-fb">Najnowsze posty z Facebooka</h2>
-
-
-  <div class="center">
-    <div id="fb-feed-loader" class="loader">Ładowanie postów…</div>
-    <div id="fb-feed-fallback" class="fallback" style="display:none;">
-      Nie udało się pobrać postów. Zobacz więcej na Facebooku:
-      <br />
-      <a class="btn" target="_blank" href="https://www.facebook.com/ExploRideURBEX">Otwórz Facebook</a>
-    </div>
-  </div>
-
-  <div id="fb-feed" class="fb-feed">
-    <div id="fb-featured" class="fb-featured" aria-live="polite"></div>
-    <div id="fb-carousel-window" class="fb-carousel-window" tabindex="0">
-      <button id="fbBtnPrev" class="nav-btn left" aria-label="Pokaż wcześniejsze posty">&#9664;</button>
-      <div id="fb-carousel" class="fb-carousel"></div>
-      <button id="fbBtnNext" class="nav-btn right" aria-label="Pokaż kolejne posty">&#9654;</button>
-    </div>
-  </div>
-  <!-- ======== /Facebook: Najnowsze posty ======== -->
+  <section id="fb-latest" class="fb-latest-section" aria-labelledby="posty-fb">
+    <div id="fb-latest-embed" class="fb-embed-card"></div>
+  </section>
+  <!-- ======== /Facebook: Najnowszy post ======== -->
 
   <hr class="divider" />
 
@@ -604,209 +588,136 @@
     © ExploRide • Urbex i podróże
   </footer>
 
+  <div id="fb-root"></div>
+  <script async defer crossorigin="anonymous"
+    src="https://connect.facebook.net/pl_PL/sdk.js#xfbml=1&version=v20.0"></script>
+
   <script>
-    // ---- USTAWIENIA ----
-    const WORKER_URL = "https://fb-feed.eksplorajder.workers.dev/api/fb/posts";
-    const FB_PAGE_ID = "145171925888318";   // Twoje Page ID
-    const FB_LIMIT   = 6;                   // ile postów pokazać
+    (function () {
+      const FB_POSTS_API = "https://fb-feed.eksplorajder.workers.dev/api/fb/posts";
+      const FB_PAGE_ID = "145171925888318";
+      const FACEBOOK_PAGE_URL = "https://www.facebook.com/ExploRideURBEX";
 
-    let fbCarousel = null;
-    let fbBtnPrev = null;
-    let fbBtnNext = null;
-    let carouselWindow = null;
-    let fbCarouselBound = false;
+      function waitForFacebookSDK() {
+        return new Promise(resolve => {
+          const finish = () => {
+            if (window.FB && typeof window.FB.XFBML?.parse === "function") {
+              resolve(window.FB);
+              return true;
+            }
+            return false;
+          };
 
-    function updateFbNav() {
-      if (!fbCarousel || !fbBtnPrev || !fbBtnNext) return;
-      const canScroll = fbCarousel.scrollHeight > fbCarousel.clientHeight + 1;
-      if (!canScroll) {
-        fbBtnPrev.style.display = "none";
-        fbBtnNext.style.display = "none";
-        return;
-      }
-      fbBtnPrev.style.display = fbCarousel.scrollTop > 0 ? "flex" : "none";
-      const maxTop = fbCarousel.scrollHeight - fbCarousel.clientHeight - 1;
-      fbBtnNext.style.display = fbCarousel.scrollTop < maxTop ? "flex" : "none";
-    }
+          if (finish()) {
+            return;
+          }
 
-    function scrollFb(offset) {
-      if (!fbCarousel) return;
-      fbCarousel.scrollBy({ top: offset, behavior: "smooth" });
-    }
-
-    function syncCarouselHeight() {
-      const featured = document.getElementById("fb-featured");
-      const win = document.getElementById("fb-carousel-window");
-      if (!featured || !win) return;
-      win.style.height = featured.offsetHeight + "px"; // prawa = dokładnie lewa
-      updateFbNav();
-    }
-
-    let fbRo;
-    function afterFbRendered() {
-      syncCarouselHeight();
-      // aktualizacja przy zmianie rozmiaru lewej karty
-      if (window.ResizeObserver && !fbRo) {
-        fbRo = new ResizeObserver(syncCarouselHeight);
-        fbRo.observe(document.getElementById("fb-featured"));
-      }
-      window.addEventListener("resize", syncCarouselHeight);
-    }
-
-    const esc = (s = "") => s.replaceAll("<", "&lt;");
-
-    const shortenText = (text = "", limit = 600) => {
-      const value = (text || "").trim();
-      if (!value) {
-        return { value: "", truncated: false };
-      }
-      if (value.length <= limit) {
-        return { value, truncated: false };
-      }
-      const slice = value.slice(0, limit);
-      const withoutLastWord = slice.replace(/\s+\S*$/, "");
-      const safe = withoutLastWord.length > limit * 0.4 ? withoutLastWord : slice;
-      const finalValue = safe.replace(/[\s\n]+$/u, "");
-      return { value: finalValue + "…", truncated: true };
-    };
-
-    const fmtDatePL = iso => {
-      const d = new Date(iso); if (isNaN(d)) return "";
-      return `${String(d.getDate()).padStart(2, "0")}.${String(d.getMonth() + 1).padStart(2, "0")}.${d.getFullYear()}`;
-    };
-
-    const postCard = (p, variant = "grid") => {
-      const media = Array.isArray(p.media) ? p.media.filter(m => m && m.src) : [];
-      const firstImg = media[0]?.src || null;
-      const classes = ["fb-card"];
-      if (variant === "featured") classes.push("fb-card--featured");
-      if (variant === "carousel") classes.push("fb-card--carousel");
-      let mediaHtml = "";
-      if (variant === "featured" && media.length > 1) {
-        const limitedMedia = media.slice(0, 5);
-        const extraCount = Math.max(media.length - limitedMedia.length, 0);
-        const gridAttrs = ` data-count="${limitedMedia.length}"`;
-        const gridItems = limitedMedia
-          .map((m, idx) => {
-            const overlay = extraCount > 0 && idx === limitedMedia.length - 1
-              ? `<span class="fb-media__more" aria-hidden="true">+${extraCount}</span>`
-              : "";
-            return `<div class="fb-featured-media-grid__item"><img src="${m.src}" alt="Post ExploRide – zdjęcie ${idx + 1}" loading="lazy">${overlay}</div>`;
-          })
-          .join("");
-        mediaHtml = `<div class="fb-featured-media-grid"${gridAttrs} role="group" aria-label="Galeria zdjęć z posta">${gridItems}</div>`;
-      } else if (firstImg) {
-        mediaHtml = `<div class="fb-media"><img src="${firstImg}" alt="Post ExploRide" loading="lazy"></div>`;
+          const previousInit = window.fbAsyncInit;
+          window.fbAsyncInit = function () {
+            if (typeof previousInit === "function") {
+              try {
+                previousInit();
+              } catch (err) {
+                console.error("fbAsyncInit error", err);
+              }
+            }
+            finish();
+          };
+        });
       }
 
-      const message = typeof p.message === "string" ? p.message : "";
-      let textData = { value: message, truncated: false };
-      if (variant === "featured") {
-        textData = shortenText(message, 600);
+      function setHostContent(host, html) {
+        if (host) {
+          host.innerHTML = html;
+        }
       }
-      const textContentClasses = ["fb-text__content"];
-      if (variant === "featured" && textData.truncated) {
-        textContentClasses.push("fb-text__content--truncated");
-      }
-      const moreLabel = variant === "featured" && textData.truncated
-        ? `<div class="fb-text__more">Kliknij i zobacz więcej</div>`
-        : "";
 
-      return `
-        <a class="${classes.join(" ")}" href="${p.permalink_url}" target="_blank" rel="noopener">
-          ${mediaHtml}
-          <div class="fb-body">
-            <div class="fb-date">${fmtDatePL(p.created_time)}</div>
-            <div class="fb-text">
-              <div class="${textContentClasses.join(" ")}">${esc(textData.value)}</div>
-              ${moreLabel}
-            </div>
+      function fallbackMarkup() {
+        return `
+          <div class="fb-embed-fallback">
+            <p>Nie udało się załadować posta z Facebooka.</p>
+            <a class="btn" target="_blank" rel="noopener" href="${FACEBOOK_PAGE_URL}">Zobacz na Facebooku</a>
           </div>
-        </a>
-      `;
-    };
-
-    async function loadFbFeed() {
-      const loader = document.getElementById("fb-feed-loader");
-      const fallback = document.getElementById("fb-feed-fallback");
-      const featured = document.getElementById("fb-featured");
-      carouselWindow = document.getElementById("fb-carousel-window");
-      fbCarousel = document.getElementById("fb-carousel");
-      fbBtnPrev = document.getElementById("fbBtnPrev");
-      fbBtnNext = document.getElementById("fbBtnNext");
-
-      if (!fbCarouselBound && fbCarousel && fbBtnPrev && fbBtnNext) {
-        fbCarouselBound = true;
-
-        // skok o wysokość widocznego okna listy
-        fbBtnPrev.addEventListener("click", () => scrollFb(-fbCarousel.clientHeight));
-        fbBtnNext.addEventListener("click", () => scrollFb( fbCarousel.clientHeight));
-
-        fbCarousel.addEventListener("scroll", updateFbNav);
-
-        if (carouselWindow) {
-          carouselWindow.addEventListener("keydown", e => {
-            if (e.key === "ArrowUp")   { e.preventDefault(); scrollFb(-fbCarousel.clientHeight); }
-            if (e.key === "ArrowDown") { e.preventDefault(); scrollFb( fbCarousel.clientHeight); }
-          });
-        }
-        window.addEventListener("resize", updateFbNav);
-
-        // wygląd strzałek: ▲ / ▼
-        if (fbBtnPrev) { fbBtnPrev.setAttribute("aria-label","Przewiń w górę"); fbBtnPrev.textContent = "▲"; }
-        if (fbBtnNext) { fbBtnNext.setAttribute("aria-label","Przewiń w dół");  fbBtnNext.textContent = "▼"; }
+        `;
       }
-      try {
-        const url = new URL(WORKER_URL);
+
+      function loadingMarkup() {
+        return '<div class="fb-embed-loading">Ładowanie posta…</div>';
+      }
+
+      async function fetchLatestPublishedPost() {
+        const url = new URL(FB_POSTS_API);
         url.searchParams.set("page_id", FB_PAGE_ID);
-        url.searchParams.set("limit", String(FB_LIMIT));
+        url.searchParams.set("limit", "1");
 
-        const res = await fetch(url.toString(), { credentials: "omit" });
-        if (!res.ok) throw new Error("HTTP " + res.status);
-        const data = await res.json();
-        const items = data.items || [];
-        if (!items.length) throw new Error("Brak postów");
-
-        const [latest, ...rest] = items;
-
-        if (latest && featured) {
-          featured.innerHTML = postCard(latest, "featured");
-          featured.style.display = "block";
-        } else if (featured) {
-          featured.innerHTML = "";
-          featured.style.display = "none";
+        const response = await fetch(url.toString(), { credentials: "omit" });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
         }
 
-        if (rest.length && fbCarousel && carouselWindow) {
-          fbCarousel.innerHTML = rest.map(p => postCard(p, "carousel")).join("");
-        } else if (fbCarousel && carouselWindow) {
-          fbCarousel.innerHTML = "";
+        const data = await response.json();
+        const items = Array.isArray(data?.items) ? data.items : [];
+        const latest = items[0] || null;
+
+        if (!latest || latest.is_published === false || !latest.permalink_url) {
+          return null;
         }
 
-        if (carouselWindow) {
-          carouselWindow.style.display = rest.length ? "block" : "none";
-        }
-
-        afterFbRendered();
-
-        loader.style.display = "none";
-        updateFbNav();
-      } catch (e) {
-        console.warn("FB feed error", e);
-        loader.style.display = "none";
-        fallback.style.display = "block";
-        if (carouselWindow) {
-          carouselWindow.style.display = "none";
-        }
-        updateFbNav();
+        return latest;
       }
-    }
 
-    if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", loadFbFeed);
-    } else {
-      loadFbFeed();
-    }
+      function buildEmbed(permalink) {
+        const cleanUrl = String(permalink || "");
+        if (!cleanUrl) {
+          return "";
+        }
+
+        const isVideo = /\/(videos|reel)\//i.test(cleanUrl);
+        if (isVideo) {
+          return `<div class="fb-video" data-href="${cleanUrl}" data-width="100%" data-show-text="true" data-allowfullscreen="true"></div>`;
+        }
+
+        return `<div class="fb-post" data-href="${cleanUrl}" data-width="100%" data-show-text="true"></div>`;
+      }
+
+      async function renderLatestFbEmbed(hostId = "fb-latest-embed") {
+        const host = document.getElementById(hostId);
+        if (!host) {
+          return;
+        }
+
+        setHostContent(host, loadingMarkup());
+
+        try {
+          const latest = await fetchLatestPublishedPost();
+          if (!latest) {
+            throw new Error("Brak opublikowanego posta");
+          }
+
+          const markup = buildEmbed(latest.permalink_url);
+          if (!markup) {
+            throw new Error("Brak poprawnego odnośnika");
+          }
+
+          setHostContent(host, markup);
+          const FB = await waitForFacebookSDK();
+          if (FB && typeof FB.XFBML?.parse === "function") {
+            FB.XFBML.parse(host);
+          }
+        } catch (err) {
+          console.warn("FB embed error", err);
+          setHostContent(host, fallbackMarkup());
+        }
+      }
+
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", () => renderLatestFbEmbed());
+      } else {
+        renderLatestFbEmbed();
+      }
+
+      window.renderLatestFbEmbed = renderLatestFbEmbed;
+    })();
   </script>
 
   <!-- Skrypt na końcu, by statyczna treść zawsze się wyświetliła -->

--- a/style.css
+++ b/style.css
@@ -652,276 +652,47 @@
       border-radius: 10px; background: #e50914; color: #fff; text-decoration: none;
     }
 
-    /* === Facebook: lewa featured, po prawej pionowy karuzel === */
-    .fb-feed{
-      display:grid;
-      grid-template-columns:minmax(0,1fr) 340px; /* zmień np. na 360/320 px */
-      gap:18px;
-      align-items:stretch;
-      max-width:1200px;
-      margin:18px auto 40px;
-      padding:0 16px;
+    /* === Facebook: pojedyncze osadzenie === */
+    .fb-latest-section {
+      max-width: 900px;
+      margin: 18px auto 40px;
+      padding: 0 16px;
     }
 
-    .fb-featured{
-      align-self:start;
-      max-width:none;
-      width:100%;
-    }
-
-    /* okno prawej kolumny = dokładnie wysokość lewej (resztę przewija w środku) */
-    .fb-carousel-window{
-      position:relative;
-      display:block !important;
-      overflow:hidden;   /* przewija tylko wnętrze */
-      min-height:0;      /* ważne dla grida, żeby overflow działał */
-      align-self:stretch;
-      border-radius: 12px;
-    }
-
-    /* pionowa lista kart */
-    .fb-carousel{
-      display:flex;
-      flex-direction:column;
-      gap:12px;
-      height:100%;
-      overflow-y:auto;         /* przewijanie góra/dół */
-      overflow-x:hidden;
-      padding-bottom:0;
-      -ms-overflow-style:auto;
-      scrollbar-width:thin;
-      overscroll-behavior:contain;
-      touch-action: pan-y;     /* swajp palcem na tel. */
-    }
-
-    /* małe karty dopasowane do szerokości prawej kolumny */
-    .fb-card--carousel{ width:100%; flex:0 0 auto; }
-
-    /* strzałki – wersja pionowa */
-    .fb-carousel-window .nav-btn {
-      left: 50%;
-      transform: translateX(-50%);
-      user-select: none;
-    }
-    #fbBtnPrev {
-      top: 8px;
-      bottom: auto;
-    }
-    #fbBtnNext {
-      bottom: 8px;
-      top: auto;
-    }
-
-    .fb-featured:empty {
-      display: none;
-    }
-
-    .fb-carousel-window:focus { outline: none; }
-
-    .fb-card {
-      background: #f1f1f1;
+    .fb-embed-card {
+      background: rgba(17, 17, 17, 0.85);
       border: 1px solid #2a2a2a;
-      border-radius: 12px;
-      overflow: hidden;
-      display: flex;
-      flex-direction: column;
-      text-align: left;
-      transition: transform 0.2s ease;
-      text-decoration: none;
-      color: inherit;
-    }
-    .fb-card:visited { color: inherit; }
-    .fb-card:hover { transform: translateY(-3px); }
-    .fb-card:focus-visible { outline: 2px solid #e50914; outline-offset: 3px; }
-    .fb-card--featured {
-      grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
-      gap: 24px;
+      border-radius: 14px;
       padding: 18px;
-    }
-    .fb-media {
-      position: relative;
-      width: 100%;
-      padding-top: 56.25%;
-      background: #000;
-      overflow: hidden;
-    }
-    .fb-card--featured .fb-media {
-      padding-top: 0;
-      aspect-ratio: 16 / 9;
-      border-radius: 12px;
-      min-height: 260px;
-    }
-    .fb-featured-media-grid {
-      position: relative;
-      display: grid;
-      grid-template-columns: repeat(6, 1fr);
-      grid-template-rows: 3fr 2fr;
-      gap: 6px;
-      width: 100%;
-      background: #000;
-      border-radius: 12px;
-      overflow: hidden;
-      aspect-ratio: 16 / 9;
-      min-height: 260px;
-    }
-    .fb-featured-media-grid__item {
-      position: relative;
-      overflow: hidden;
-      background: #000;
-    }
-    .fb-featured-media-grid__item:nth-child(1) {
-      grid-column: 1 / span 3;
-      grid-row: 1;
-    }
-    .fb-featured-media-grid__item:nth-child(2) {
-      grid-column: 4 / span 3;
-      grid-row: 1;
-    }
-    .fb-featured-media-grid__item:nth-child(3) {
-      grid-column: 1 / span 2;
-      grid-row: 2;
-    }
-    .fb-featured-media-grid__item:nth-child(4) {
-      grid-column: 3 / span 2;
-      grid-row: 2;
-    }
-    .fb-featured-media-grid__item:nth-child(5) {
-      grid-column: 5 / span 2;
-      grid-row: 2;
-    }
-    .fb-featured-media-grid[data-count="2"] {
-      grid-template-rows: 1fr;
-    }
-    .fb-featured-media-grid[data-count="3"] .fb-featured-media-grid__item:nth-child(3) {
-      grid-column: 1 / span 6;
-      grid-row: 2;
-    }
-    .fb-featured-media-grid[data-count="4"] .fb-featured-media-grid__item:nth-child(3) {
-      grid-column: 1 / span 3;
-      grid-row: 2;
-    }
-    .fb-featured-media-grid[data-count="4"] .fb-featured-media-grid__item:nth-child(4) {
-      grid-column: 4 / span 3;
-      grid-row: 2;
-    }
-    .fb-featured-media-grid__item img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      display: block;
-    }
-    .fb-media img {
-      position: absolute;
-      inset: 0;
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      display: block;
-    }
-    .fb-card--featured .fb-media img {
-      border-radius: 12px;
-    }
-    .fb-media__more {
-      position: absolute;
-      right: 12px;
-      bottom: 12px;
-      padding: 6px 12px;
-      border-radius: 999px;
-      background: rgba(0, 0, 0, 0.7);
-      color: #fff;
-      font-size: 1.05em;
-      font-weight: 600;
-      letter-spacing: 0.03em;
-      pointer-events: none;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
-      display: none;
-    }
-    .fb-featured-media-grid__item:last-child .fb-media__more {
-      right: 10px;
-      bottom: 10px;
-    }
-    .fb-body { padding: 12px 14px; }
-    .fb-card--featured .fb-body {
-      padding: 0;
       display: flex;
-      flex-direction: column;
-      gap: 14px;
-      justify-content: flex-start;
-    }
-    .fb-date {
-      font-size: 0.9em;
-      color: #2c2c2c;
-      margin-bottom: 6px;
-    }
-    .fb-card--featured .fb-date {
-      font-size: 0.95em;
-      color: #1c1c1c;
-    }
-    .fb-text {
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-      color: #111111;
-      font-size: 0.98em;
-      line-height: 1.35;
-    }
-    .fb-text__content {
-      white-space: pre-wrap;
-      max-height: 6.5em;
-      overflow: hidden;
-    }
-    .fb-card--featured .fb-text {
-      font-size: 1.05em;
-      line-height: 1.45;
-      color: #1c1c1c;
-    }
-    .fb-card--featured .fb-text__content {
-      max-height: none;
-    }
-    .fb-text__content--truncated {
-      position: relative;
-      display: -webkit-box;
-      -webkit-box-orient: vertical;
-      -webkit-line-clamp: 6;
-      overflow: hidden;
-    }
-    .fb-text__content--truncated::after {
-      content: "";
-      position: absolute;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      height: 2.1em;
-      background: linear-gradient(180deg, rgba(241, 241, 241, 0) 0%, #f1f1f1 85%);
-      pointer-events: none;
-    }
-    .fb-text__more {
-      font-size: 0.92em;
-      font-weight: 600;
-      color: #444;
-    }
-    .fb-card--featured .fb-text__more {
-      color: #1c1c1c;
-    }
-    .fb-card--carousel .fb-text__content {
-      max-height: 5.4em;
-    }
-    /* Mobile: jedna kolumna, naturalna wysokość, bez strzałek */
-    @media (max-width:900px){
-      .fb-feed{ display:flex; flex-direction:column; }
-      .fb-carousel-window{ height:auto !important; }
-      .fb-carousel{ max-height:none; overflow:visible; }
-      #fbBtnPrev,#fbBtnNext{ display:none !important; }
-    }
-    @media (max-width: 1024px) {
-      .fb-card--featured {
-        grid-template-columns: 1fr;
-      }
-      .fb-card--featured .fb-body {
-        padding-top: 12px;
-      }
+      justify-content: center;
+      align-items: stretch;
+      min-height: 180px;
+      box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
     }
 
+    .fb-embed-card > * {
+      width: 100%;
+    }
+
+    .fb-embed-loading,
+    .fb-embed-fallback {
+      margin: 0;
+      width: 100%;
+      text-align: center;
+      color: #ddd;
+      font-size: 1rem;
+    }
+
+    .fb-embed-fallback a.btn {
+      margin-top: 12px;
+    }
+
+    @media (max-width: 600px) {
+      .fb-embed-card {
+        padding: 14px;
+      }
+    }
     /* O nas */
     .about-main {
       max-width: 960px;

--- a/worker/index.js
+++ b/worker/index.js
@@ -155,7 +155,7 @@ async function getFbPosts(pageId, token, limit) {
   const u = new URL(`https://graph.facebook.com/v19.0/${encodeURIComponent(pageId)}/posts`);
   u.searchParams.set(
     'fields',
-    'id,message,permalink_url,created_time,full_picture,attachments{media_type,media,subattachments{media}}'
+    'id,message,permalink_url,created_time,is_published,full_picture,attachments{media_type,media,subattachments{media}}'
   );
   u.searchParams.set('limit', String(limit));
   u.searchParams.set('access_token', token);
@@ -179,6 +179,7 @@ async function getFbPosts(pageId, token, limit) {
         message: post.message || '',
         permalink_url: post.permalink_url || '',
         created_time: post.created_time || '',
+        is_published: post.is_published !== false,
         media: collectPostMedia(post)
       }))
     : [];


### PR DESCRIPTION
## Summary
- replace the Facebook feed markup with a single container for the official plugin
- load the Facebook SDK once and render the most recent permalink returned by the worker API
- streamline Facebook styles and expose the worker response flag for published posts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdb00a5f408330a07aa1961dce138a