### PR TITLE
Filter unpublished Facebook posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -657,9 +657,10 @@
 
         const data = await response.json();
         const items = Array.isArray(data?.items) ? data.items : [];
-        const latest = items[0] || null;
+        const latest =
+          items.find(item => item && item.is_published !== false && item.permalink_url) || null;
 
-        if (!latest || latest.is_published === false || !latest.permalink_url) {
+        if (!latest) {
           return null;
         }
 

--- a/worker/index.js
+++ b/worker/index.js
@@ -173,7 +173,7 @@ async function getFbPosts(pageId, token, limit) {
     throw new Error(`FB posts fetch failed: ${message}`);
   }
 
-  const items = Array.isArray(data.data)
+  const mappedItems = Array.isArray(data.data)
     ? data.data.map(post => ({
         id: post.id,
         message: post.message || '',
@@ -183,6 +183,8 @@ async function getFbPosts(pageId, token, limit) {
         media: collectPostMedia(post)
       }))
     : [];
+
+  const items = mappedItems.filter(item => item.is_published !== false && item.permalink_url);
 
   items.sort((a, b) => {
     const ta = a.created_time ? Date.parse(a.created_time) : 0;


### PR DESCRIPTION
## Summary
- filter Facebook worker responses to exclude unpublished or permalink-less entries before sorting and slicing
- update the homepage embed logic to pick the first publishable Facebook post with a permalink

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdb6eb598c8330b1f90dbc2cd62f68