### PR TITLE
Switch Facebook embed to oEmbed with worker endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -597,11 +597,34 @@
       const FB_POSTS_API = "https://fb-feed.eksplorajder.workers.dev/api/fb/posts";
       const FB_PAGE_ID = "145171925888318";
       const FACEBOOK_PAGE_URL = "https://www.facebook.com/ExploRideURBEX";
+      const WORKER_URL = (() => {
+        try {
+          return new URL(FB_POSTS_API).origin;
+        } catch (err) {
+          return "";
+        }
+      })();
+      const FB_OEMBED_API = (() => {
+        if (WORKER_URL) {
+          return `${WORKER_URL}/api/fb/oembed`;
+        }
+        try {
+          return new URL("/api/fb/oembed", FB_POSTS_API).toString();
+        } catch (err) {
+          return "";
+        }
+      })();
 
-      function waitForFacebookSDK() {
+      function waitForFacebookSDK(timeoutMs = 5000) {
         return new Promise(resolve => {
+          let resolved = false;
+
           const finish = () => {
+            if (resolved) {
+              return true;
+            }
             if (window.FB && typeof window.FB.XFBML?.parse === "function") {
+              resolved = true;
               resolve(window.FB);
               return true;
             }
@@ -612,6 +635,16 @@
             return;
           }
 
+          let timeoutId = null;
+          if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+            timeoutId = setTimeout(() => {
+              if (!resolved) {
+                resolved = true;
+                resolve(null);
+              }
+            }, timeoutMs);
+          }
+
           const previousInit = window.fbAsyncInit;
           window.fbAsyncInit = function () {
             if (typeof previousInit === "function") {
@@ -620,6 +653,9 @@
               } catch (err) {
                 console.error("fbAsyncInit error", err);
               }
+            }
+            if (timeoutId) {
+              clearTimeout(timeoutId);
             }
             finish();
           };
@@ -635,8 +671,7 @@
       function fallbackMarkup() {
         return `
           <div class="fb-embed-fallback">
-            <p>Nie udało się załadować posta z Facebooka.</p>
-            <a class="btn" target="_blank" rel="noopener" href="${FACEBOOK_PAGE_URL}">Zobacz na Facebooku</a>
+            <a class="btn" target="_blank" rel="noopener" href="${FACEBOOK_PAGE_URL}">Zobacz najnowszy post na Facebooku</a>
           </div>
         `;
       }
@@ -645,10 +680,38 @@
         return '<div class="fb-embed-loading">Ładowanie posta…</div>';
       }
 
+      function normalizePermalink(post) {
+        if (!post) {
+          return null;
+        }
+        const candidates = [post.permalink_url, post.permalink, post.url];
+        for (const candidate of candidates) {
+          if (typeof candidate === "string") {
+            const trimmed = candidate.trim();
+            if (trimmed) {
+              return trimmed;
+            }
+          }
+        }
+        return null;
+      }
+
+      function isRenderable(post) {
+        return post?.is_published !== false && !!normalizePermalink(post);
+      }
+
+      function pickFirstRenderable(items) {
+        return Array.isArray(items) ? items.find(isRenderable) || null : null;
+      }
+
+      function isVideoPermalink(permalink) {
+        return /\/(videos|reel)\//i.test(String(permalink || ""));
+      }
+
       async function fetchLatestPublishedPost() {
         const url = new URL(FB_POSTS_API);
         url.searchParams.set("page_id", FB_PAGE_ID);
-        url.searchParams.set("limit", "1");
+        url.searchParams.set("limit", "10");
 
         const response = await fetch(url.toString(), { credentials: "omit" });
         if (!response.ok) {
@@ -657,24 +720,51 @@
 
         const data = await response.json();
         const items = Array.isArray(data?.items) ? data.items : [];
-        const latest =
-          items.find(item => item && item.is_published !== false && item.permalink_url) || null;
-
-        if (!latest) {
-          return null;
-        }
-
-        return latest;
+        return pickFirstRenderable(items);
       }
 
-      function buildEmbed(permalink) {
-        const cleanUrl = String(permalink || "");
+      async function fetchOEmbedHtml(permalink) {
+        if (!FB_OEMBED_API) {
+          throw new Error("Brak endpointu oEmbed");
+        }
+
+        const targetPermalink = normalizePermalink({ permalink_url: permalink });
+        if (!targetPermalink) {
+          throw new Error("Brak permalinku do oEmbed");
+        }
+
+        let requestUrl;
+        try {
+          requestUrl = new URL(FB_OEMBED_API);
+        } catch (err) {
+          throw new Error("Niepoprawny adres oEmbed");
+        }
+
+        requestUrl.searchParams.set("url", targetPermalink);
+        requestUrl.searchParams.set("maxwidth", "780");
+        requestUrl.searchParams.set("omitscript", "true");
+
+        const response = await fetch(requestUrl.toString(), { credentials: "omit" });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+
+        const data = await response.json();
+        const html = typeof data?.html === "string" ? data.html : "";
+        if (!html) {
+          throw new Error("Brak treści oEmbed");
+        }
+
+        return html;
+      }
+
+      function buildXfbmlMarkup(permalink) {
+        const cleanUrl = normalizePermalink({ permalink_url: permalink });
         if (!cleanUrl) {
           return "";
         }
 
-        const isVideo = /\/(videos|reel)\//i.test(cleanUrl);
-        if (isVideo) {
+        if (isVideoPermalink(cleanUrl)) {
           return `<div class="fb-video" data-href="${cleanUrl}" data-width="100%" data-show-text="true" data-allowfullscreen="true"></div>`;
         }
 
@@ -692,19 +782,35 @@
         try {
           const latest = await fetchLatestPublishedPost();
           if (!latest) {
-            throw new Error("Brak opublikowanego posta");
+            throw new Error("Brak renderowalnego posta");
           }
 
-          const markup = buildEmbed(latest.permalink_url);
-          if (!markup) {
+          const permalink = normalizePermalink(latest);
+          if (!permalink) {
             throw new Error("Brak poprawnego odnośnika");
+          }
+
+          try {
+            const html = await fetchOEmbedHtml(permalink);
+            setHostContent(host, html);
+            return;
+          } catch (oEmbedErr) {
+            console.warn("FB oEmbed error", oEmbedErr);
+          }
+
+          const markup = buildXfbmlMarkup(permalink);
+          if (!markup) {
+            throw new Error("Brak danych do renderowania XFBML");
           }
 
           setHostContent(host, markup);
           const FB = await waitForFacebookSDK();
           if (FB && typeof FB.XFBML?.parse === "function") {
             FB.XFBML.parse(host);
+            return;
           }
+
+          throw new Error("FB SDK unavailable");
         } catch (err) {
           console.warn("FB embed error", err);
           setHostContent(host, fallbackMarkup());


### PR DESCRIPTION
## Summary
- update the Facebook section to request multiple posts, pick the first renderable item, and prefer oEmbed rendering with an SDK fallback
- add a Cloudflare Worker `/api/fb/oembed` endpoint and reuse filtered post data before slicing the results
- ensure the UI falls back to a Facebook page link when neither oEmbed nor the SDK can render content

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cdbbd5061c8330bd1906820358117c