### PR TITLE
Adjust Facebook oEmbed handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -793,7 +793,16 @@
           try {
             const html = await fetchOEmbedHtml(permalink);
             setHostContent(host, html);
-            return;
+
+            // KLUCZOWE: oEmbed bez skryptu wymaga ręcznego parsowania XFBML
+            const FBSDK = await waitForFacebookSDK(7000);
+            if (FBSDK && typeof FBSDK.XFBML?.parse === "function") {
+              FBSDK.XFBML.parse(host);
+              return; // mamy działający embed
+            }
+
+            // awaryjnie spróbujmy render XFBML niżej (zrobisz to już w istniejącym fallbacku)
+            console.warn("FB SDK niegotowe po oEmbed – lecę fallbackiem");
           } catch (oEmbedErr) {
             console.warn("FB oEmbed error", oEmbedErr);
           }

--- a/worker/index.js
+++ b/worker/index.js
@@ -226,11 +226,9 @@ async function handleFbOEmbed(url, env) {
     fbUrl.searchParams.set('maxwidth', maxWidth);
   }
 
-  const omitScriptParam = url.searchParams.has('omitscript')
-    ? url.searchParams.get('omitscript') || 'true'
-    : 'true';
-  if (omitScriptParam) {
-    fbUrl.searchParams.set('omitscript', omitScriptParam);
+  const omitscript = url.searchParams.get('omitscript');
+  if (omitscript === 'true' || omitscript === 'false') {
+    fbUrl.searchParams.set('omitscript', omitscript);
   }
 
   const res = await fetch(fbUrl.toString());


### PR DESCRIPTION
## Summary
- trigger XFBML parsing after inserting oEmbed markup and warn before falling back
- forward the `omitscript` flag to Facebook only when explicitly provided

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdcb4e1df0833088fd29e63ff56de9