### PR TITLE
Fix Facebook oEmbed CORS handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -740,6 +740,7 @@
           throw new Error("Niepoprawny adres oEmbed");
         }
 
+        requestUrl.searchParams.set("page_id", FB_PAGE_ID);
         requestUrl.searchParams.set("url", targetPermalink);
         requestUrl.searchParams.set("maxwidth", "780");
         requestUrl.searchParams.set("omitscript", "true");


### PR DESCRIPTION
## Summary
- unify the worker CORS implementation with a single allowlist-aware helper
- adjust the Facebook oEmbed handler to always respond with CORS headers and improved error reporting
- include the Facebook page identifier in front-end oEmbed requests

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cdd085bce08330a8813a9da7f647e5