### PR TITLE
Use transparent logo background in header

### DIFF
--- a/style.css
+++ b/style.css
@@ -104,6 +104,26 @@
       margin-bottom: 50px;
       box-shadow: 0 0 20px 6px #000;
       text-align: center;
+      position: relative;
+      overflow: hidden;
+    }
+
+    header::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background-image: url('logo.png');
+      background-repeat: no-repeat;
+      background-position: center;
+      background-size: auto 75%;
+      opacity: 0.3;
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    header > * {
+      position: relative;
+      z-index: 1;
     }
     .brand {
       display: inline-flex;
@@ -126,9 +146,7 @@
     }
 
     header .logo {
-      width: clamp(160px, 32vw, 280px);
-      height: auto;
-      max-width: 100%;
+      display: none;
     }
     .nav-toggle {
       display: none;


### PR DESCRIPTION
## Summary
- add a pseudo-element to render the ExploRide logo as the header background at 70% transparency and 75% of the header height
- hide the inline logo image so the background treatment is visible while keeping the brand text readable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf2e91dfb883309d590518188608fb