### PR TITLE
Adjust playlist grid on videos page

### DIFF
--- a/style.css
+++ b/style.css
@@ -664,6 +664,33 @@
 
     .playlist-window:focus { outline: none; }
 
+    .page-videos .playlist-window {
+      overflow: visible;
+    }
+
+    .page-videos .playlist-list {
+      display: grid;
+      grid-auto-flow: column;
+      grid-template-rows: repeat(2, minmax(0, 1fr));
+      grid-auto-columns: minmax(240px, 1fr);
+      column-gap: 18px;
+      row-gap: 18px;
+      padding-bottom: 8px;
+    }
+
+    .page-videos .playlist-list .video-tile {
+      width: 100%;
+      flex: initial;
+    }
+
+    @media (max-width: 640px) {
+      .page-videos .playlist-list {
+        grid-auto-flow: row;
+        grid-template-rows: none;
+        grid-template-columns: 1fr;
+      }
+    }
+
     .center { max-width: 1200px; margin: 0 auto; padding: 0 16px; }
     .loader { margin: 16px auto 0; color: #bbb; font-size: 0.95em; }
     .fallback {


### PR DESCRIPTION
## Summary
- update the shared styles so the videos page playlist uses a two-row grid layout
- scope the grid override to the videos page while keeping the homepage slider unchanged, including a mobile fallback

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68d6327e42b8833091fec912d2c64a30