### PR TITLE
Replace embedded YouTube subscribe control with custom button

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,15 +267,15 @@
                   allowfullscreen
                 ></iframe>
               </div>
-              <div class="g-ytsubscribe"
-                   data-channelid="UCDDh55aHt6hRAjIu5BIkrUQ"
-                   data-layout="full"
-                   data-count="default"></div>
-              <noscript>
-                <a href="https://www.youtube.com/channel/UCDDh55aHt6hRAjIu5BIkrUQ?sub_confirmation=1" target="_blank" rel="noopener">
-                  Subskrybuj ExploRide
-                </a>
-              </noscript>
+              <a
+                class="youtube-subscribe-button"
+                href="https://www.youtube.com/channel/UCDDh55aHt6hRAjIu5BIkrUQ?sub_confirmation=1"
+                target="_blank"
+                rel="noopener"
+                aria-label="Subskrybuj kanał ExploRide na YouTube"
+              >
+                Subskrybuj
+              </a>
             </div>
           </div>
         </section>

--- a/style.css
+++ b/style.css
@@ -345,6 +345,43 @@
       margin: 10px auto 8px;
       padding: 0 16px;
     }
+    .youtube-subscribe-button {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      margin: 18px auto 0;
+      padding: 0.65em 1.8em;
+      background: linear-gradient(135deg, #ff0000, #cc0000);
+      color: #fff;
+      font-weight: 600;
+      font-size: clamp(0.95rem, 2.6vw, 1.1rem);
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      text-decoration: none;
+      border-radius: 999px;
+      box-shadow: 0 10px 24px rgba(204, 0, 0, 0.45);
+      transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+    }
+    .youtube-subscribe-button::before {
+      content: "";
+      display: inline-block;
+      width: 0;
+      height: 0;
+      border-left: 12px solid #fff;
+      border-top: 7px solid transparent;
+      border-bottom: 7px solid transparent;
+      filter: drop-shadow(0 0 4px rgba(0, 0, 0, 0.35));
+    }
+    .youtube-subscribe-button:hover,
+    .youtube-subscribe-button:focus {
+      background: linear-gradient(135deg, #ff3b30, #d30000);
+      box-shadow: 0 12px 26px rgba(204, 0, 0, 0.6);
+      transform: translateY(-1px);
+    }
+    .youtube-subscribe-button:focus {
+      outline: 2px solid rgba(255, 255, 255, 0.6);
+      outline-offset: 4px;
+    }
     .video-switcher {
       position: relative;
       max-width: 1400px;


### PR DESCRIPTION
## Summary
- replace the YouTube g-ytsubscribe widget with a direct link button that opens the channel subscription confirmation page
- add styling for the new button so it mimics YouTube's rounded red subscribe control, including hover and focus feedback

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d67639db2c8330865ee81b529df03b