### PR TITLE
Adjust navigation button sizing and brand alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -133,7 +133,6 @@
       color: #fff;
       text-decoration: none;
       transition: color 0.2s ease;
-      left: -650px;
     }
     .brand:hover,
     .brand:focus-visible { color: #e50914; }
@@ -202,17 +201,16 @@
     }
     .top-nav {
       display: flex;
-      flex-wrap: wrap;
+      flex-wrap: nowrap;
       justify-content: center;
-      gap: clamp(14px, 3vw, 26px);
+      gap: clamp(10px, 2.2vw, 20px);
       font-family: 'BebasNeue', 'Base02', Arial, Helvetica, sans-serif;
-
     }
     .nav-link {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      padding: clamp(12px, 2.4vw, 18px) clamp(22px, 4vw, 32px);
+      padding: clamp(8px, 1.6vw, 14px) clamp(16px, 3vw, 24px);
       border-radius: 999px;
       border: 1px solid rgba(255, 255, 255, 0.12);
       background: rgb(52, 52, 52);


### PR DESCRIPTION
## Summary
- reduce navigation button padding and spacing so the links render in a single line
- remove the artificial brand offset so the site name is centered in the header

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d679b3211483308bffbdc7513546e8