### PR TITLE
Allow top navigation to wrap across rows

### DIFF
--- a/style.css
+++ b/style.css
@@ -201,9 +201,11 @@
     }
     .top-nav {
       display: flex;
-      flex-wrap: nowrap;
+      flex-wrap: wrap;
       justify-content: center;
-      gap: clamp(10px, 2.2vw, 20px);
+      align-content: center;
+      column-gap: clamp(10px, 2.2vw, 20px);
+      row-gap: clamp(8px, 2vw, 16px);
       font-family: 'BebasNeue', 'Base02', Arial, Helvetica, sans-serif;
     }
     .nav-link {


### PR DESCRIPTION
## Summary
- allow the desktop navigation bar to wrap when there are many links
- center wrapped rows and tweak vertical spacing for a consistent layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d67c0d8520833080e18a5a337f07e4