### PR TITLE
Use image preview for downloadable logo

### DIFF
--- a/materialy.html
+++ b/materialy.html
@@ -45,9 +45,9 @@
     <p class="lead">Pobierz oficjalne logo ExploRide, aby wykorzystać je w grafikach, artykułach lub materiałach promocyjnych.</p>
 
     <section class="download-card">
-      <object class="download-preview" data="logo.pdf#toolbar=0&navpanes=0&scrollbar=0" type="application/pdf" aria-label="Podgląd logo ExploRide">
-        <p>Twoja przeglądarka nie obsługuje podglądu PDF. <a href="logo.pdf">Pobierz logo</a>.</p>
-      </object>
+      <a class="download-preview" href="logo.pdf" download aria-label="Podgląd logo ExploRide">
+        <img src="logo.png" alt="Podgląd logo ExploRide">
+      </a>
 
       <div class="download-info">
         <h2>Logo ExploRide</h2>

--- a/style.css
+++ b/style.css
@@ -867,12 +867,16 @@
       border: 1px solid #2a2a2a;
       background: #fff;
       box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
     }
-    .download-preview p {
-      margin: 0;
-      padding: 12px;
-      font-size: 0.9em;
-      color: #222;
+    .download-preview img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      padding: 16px;
     }
     .download-info {
       max-width: 420px;


### PR DESCRIPTION
## Summary
- replace the PDF object preview on the downloads page with a clickable image preview that links to the PDF download
- adjust the download preview styling so the image is centered and scales within the frame

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68d67e6d553c83308e6015c7840d278d