### PR TITLE
Align Linki page buttons with homepage style

### DIFF
--- a/linki.html
+++ b/linki.html
@@ -45,34 +45,55 @@
     <section class="links-card" aria-labelledby="links-title">
       <h1 id="links-title">Linki</h1>
       <p class="links-lead">Zebraliśmy w jednym miejscu wszystkie oficjalne profile i kanały ExploRide. Kliknij w przycisk, aby odwiedzić nas na ulubionej platformie.</p>
-      <div class="links-buttons" role="list">
-        <a class="nav-link links-button links-button--yt" href="https://www.youtube.com/@ExploRideURBEX" target="_blank" rel="noopener noreferrer" role="listitem">
-          <span class="links-button__title">YouTube</span>
-          <span class="links-button__handle">@ExploRideURBEX</span>
+      <div class="links-buttons buttons" role="list">
+        <a class="links-button links-button--yt yt" href="https://www.youtube.com/@ExploRideURBEX" target="_blank" rel="noopener noreferrer" role="listitem">
+          <svg class="links-button__icon" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg>
+          <span class="links-button__text">
+            <span class="links-button__title">YouTube</span>
+            <span class="links-button__handle">@ExploRideURBEX</span>
+          </span>
         </a>
-        <a class="nav-link links-button links-button--ig" href="https://www.instagram.com/exploride.urbex" target="_blank" rel="noopener noreferrer" role="listitem">
-          <span class="links-button__title">Instagram</span>
-          <span class="links-button__handle">@exploride.urbex</span>
+        <a class="links-button links-button--ig ig" href="https://www.instagram.com/exploride.urbex" target="_blank" rel="noopener noreferrer" role="listitem">
+          <svg class="links-button__icon" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M7.0301.084c-1.2768.0602-2.1487.264-2.911.5634-.7888.3075-1.4575.72-2.1228 1.3877-.6652.6677-1.075 1.3368-1.3802 2.127-.2954.7638-.4956 1.6365-.552 2.914-.05641.2775-.0689 1.6882-.0626 4.947.0062 3.2586.0206 3.6671.0825 4.9473.061 1.2765.264 2.1482.5635 2.9107.308.7889.72 1.4573 1.388 2.1228.6679.6655 1.3365 1.0743 2.1285 1.38.7632.295 1.6361.4961 2.9134.552 1.2773.056 1.6884.069 4.9462.0627 3.2578-.0062 3.668-.0207 4.9478-.0814 1.28-.0607 2.147-.2652 2.9098-.5633.7889-.3086 1.4578-.72 2.1228-1.3881.665-.6682 1.0745-1.3378 1.3795-2.1284.2957-.7632.4966-1.636.552-2.9124.056-1.2809.0692-1.6898.063-4.948-.0063-3.2583-.021-3.6668-.0817-4.9465-.0607-1.2797-.264-2.1487-.5633-2.9117-.3084-.7889-.72-1.4568-1.3876-2.1228C21.2982 1.33 20.628.9208 19.8378.6165 19.074.321 18.2017.1197 16.9244.0645 15.6471.0093 15.236-.005 11.977.0014 8.718.0076 8.31.0215 7.0301.0839m.1402 21.6932c-1.17-.0509-1.8053-.2453-2.2287-.408-.5606-.216-.96-.4771-1.3819-.895-.422-.4178-.6811-.8186-.9-1.378-.1644-.4234-.3624-1.058-.4171-2.228-.0595-1.2645-.072-1.6442-.079-4.848-.007-3.2037.0053-3.583.0607-4.848.05-1.169.2456-1.805.408-2.2282.216-.5613.4762-.96.895-1.3816.4188-.4217.8184-.6814 1.3783-.9003.423-.1651 1.0575-.3614 2.227-.4171 1.2655-.06 1.6447-.072 4.848-.079 3.2033-.007 3.5835.005 4.8495.0608 1.169.0508 1.8053.2445 2.228.408.5608.216.96.4754 1.3816.895.4217.4194.6816.8176.9005 1.3787.1653.4217.3617 1.056.4169 2.2263.0602 1.2655.0739 1.645.0796 4.848.0058 3.203-.0055 3.5834-.061 4.848-.051 1.17-.245 1.8055-.408 2.2294-.216.5604-.4763.96-.8954 1.3814-.419.4215-.8181.6811-1.3783.9-.4224.1649-1.0577.3617-2.2262.4174-1.2656.0595-1.6448.072-4.8493.079-3.2045.007-3.5825-.006-4.848-.0608M16.953 5.5864A1.44 1.44 0 1 0 18.39 4.144a1.44 1.44 0 0 0-1.437 1.4424M5.8385 12.012c.0067 3.4032 2.7706 6.1557 6.173 6.1493 3.4026-.0065 6.157-2.7701 6.1506-6.1733-.0065-3.4032-2.771-6.1565-6.174-6.1498-3.403.0067-6.156 2.771-6.1496 6.1738M8 12.0077a4 4 0 1 1 4.008 3.9921A3.9996 3.9996 0 0 1 8 12.0077"/></svg>
+          <span class="links-button__text">
+            <span class="links-button__title">Instagram</span>
+            <span class="links-button__handle">@exploride.urbex</span>
+          </span>
         </a>
-        <a class="nav-link links-button links-button--fb" href="https://www.facebook.com/ExploRideURBEX" target="_blank" rel="noopener noreferrer" role="listitem">
-          <span class="links-button__title">Facebook</span>
-          <span class="links-button__handle">ExploRideURBEX</span>
+        <a class="links-button links-button--fb fb" href="https://www.facebook.com/ExploRideURBEX" target="_blank" rel="noopener noreferrer" role="listitem">
+          <svg class="links-button__icon" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M9.101 23.691v-7.98H6.627v-3.667h2.474v-1.58c0-4.085 1.848-5.978 5.858-5.978.401 0 .955.042 1.468.103a8.68 8.68 0 0 1 1.141.195v3.325a8.623 8.623 0 0 0-.653-.036 26.805 26.805 0 0 0-.733-.009c-.707 0-1.259.096-1.675.309a1.686 1.686 0 0 0-.679.622c-.258.42-.374.995-.374 1.752v1.297h3.919l-.386 2.103-.287 1.564h-3.246v8.245C19.396 23.238 24 18.179 24 12.044c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.628 3.874 10.35 9.101 11.647Z"/></svg>
+          <span class="links-button__text">
+            <span class="links-button__title">Facebook</span>
+            <span class="links-button__handle">ExploRideURBEX</span>
+          </span>
         </a>
-        <a class="nav-link links-button links-button--tt" href="https://www.tiktok.com/@exploride.urbex" target="_blank" rel="noopener noreferrer" role="listitem">
-          <span class="links-button__title">TikTok</span>
-          <span class="links-button__handle">@exploride.urbex</span>
+        <a class="links-button links-button--tt tt" href="https://www.tiktok.com/@exploride.urbex" target="_blank" rel="noopener noreferrer" role="listitem">
+          <svg class="links-button__icon" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M12.525.02c1.31-.02 2.61-.01 3.91-.02.08 1.53.63 3.09 1.75 4.17 1.12 1.11 2.7 1.62 4.24 1.79v4.03c-1.44-.05-2.89-.35-4.2-.97-.57-.26-1.1-.59-1.62-.93-.01 2.92.01 5.84-.02 8.75-.08 1.4-.54 2.79-1.35 3.94-1.31 1.92-3.58 3.17-5.91 3.21-1.43.08-2.86-.31-4.08-1.03-2.02-1.19-3.44-3.37-3.65-5.71-.02-.5-.03-1-.01-1.49.18-1.9 1.12-3.72 2.58-4.96 1.66-1.44 3.98-2.13 6.15-1.72.02 1.48-.04 2.96-.04 4.44-.99-.32-2.15-.23-3.02.37-.63.41-1.11 1.04-1.36 1.75-.21.51-.15 1.07-.14 1.61.24 1.64 1.82 3.02 3.5 2.87 1.12-.01 2.19-.66 2.77-1.61.19-.33.4-.67.41-1.06.1-1.79.06-3.57.07-5.36.01-4.03-.01-8.05.02-12.07z"/></svg>
+          <span class="links-button__text">
+            <span class="links-button__title">TikTok</span>
+            <span class="links-button__handle">@exploride.urbex</span>
+          </span>
         </a>
-        <a class="nav-link links-button links-button--pinterest" href="https://pin.it/7jtt0sZdS" target="_blank" rel="noopener noreferrer" role="listitem">
-          <span class="links-button__title">Pinterest</span>
-          <span class="links-button__handle">Inspiracje ExploRide</span>
+        <a class="links-button links-button--pinterest" href="https://pin.it/7jtt0sZdS" target="_blank" rel="noopener noreferrer" role="listitem">
+          <svg class="links-button__icon" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M12 0C5.373 0 0 5.373 0 12c0 4.992 3.657 9.128 8.438 10.125-.117-.86-.223-2.185.047-3.13.242-.826 1.558-5.273 1.558-5.273s-.398-.796-.398-1.972c0-1.848 1.072-3.228 2.406-3.228 1.135 0 1.68.852 1.68 1.874 0 1.142-.727 2.848-1.101 4.43-.314 1.329.667 2.414 1.977 2.414 2.373 0 3.969-3.045 3.969-6.647 0-2.744-1.849-4.801-5.216-4.801-3.801 0-6.168 2.846-6.168 6.019 0 1.094.422 2.271.949 2.908a.383.383 0 0 1 .088.367c-.096.403-.311 1.288-.354 1.467-.055.23-.179.279-.414.168-1.542-.717-2.505-2.966-2.505-4.775 0-3.887 2.828-7.454 8.138-7.454 4.277 0 7.6 3.053 7.6 7.14 0 4.247-2.68 7.666-6.404 7.666-1.25 0-2.422-.648-2.826-1.413l-.767 2.922c-.278 1.07-1.032 2.411-1.541 3.228A11.998 11.998 0 0 0 24 12c0-6.627-5.373-12-12-12z"/></svg>
+          <span class="links-button__text">
+            <span class="links-button__title">Pinterest</span>
+            <span class="links-button__handle">Inspiracje ExploRide</span>
+          </span>
         </a>
-        <a class="nav-link links-button links-button--ig-channel" href="https://www.instagram.com/channel/AbYlp0UgW0XJ3NTr/" target="_blank" rel="noopener noreferrer" role="listitem">
-          <span class="links-button__title">Kanał nadawczy IG</span>
-          <span class="links-button__handle">Dołącz na Instagramie</span>
+        <a class="links-button links-button--ig-channel ig" href="https://www.instagram.com/channel/AbYlp0UgW0XJ3NTr/" target="_blank" rel="noopener noreferrer" role="listitem">
+          <svg class="links-button__icon" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M4.5 6.75a2.25 2.25 0 0 1 2.25-2.25h.88l8.45-3.36a1 1 0 0 1 1.37.92v18.88a1 1 0 0 1-1.37.92L7.63 18.5v2.75a2.25 2.25 0 0 1-4.5 0v-6.5a2.25 2.25 0 0 1 1.37-2.07 2.25 2.25 0 0 1-.01-.22Zm2.25-.75a.75.75 0 0 0-.75.75v6.5c0 .41-.33.75-.75.75s-.75.34-.75.75v6.5a.75.75 0 0 0 1.5 0v-3.1a.75.75 0 0 1 1.1-.66l9.15 4.53V3.28L7.8 7.02a.75.75 0 0 1-.33.08Z"/></svg>
+          <span class="links-button__text">
+            <span class="links-button__title">Kanał nadawczy IG</span>
+            <span class="links-button__handle">Dołącz na Instagramie</span>
+          </span>
         </a>
-        <a class="nav-link links-button links-button--messenger" href="https://www.messenger.com/channel/ExploRideURBEX" target="_blank" rel="noopener noreferrer" role="listitem">
-          <span class="links-button__title">Kanał Messenger</span>
-          <span class="links-button__handle">ExploRideURBEX</span>
+        <a class="links-button links-button--messenger" href="https://www.messenger.com/channel/ExploRideURBEX" target="_blank" rel="noopener noreferrer" role="listitem">
+          <svg class="links-button__icon" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M12 2.04c-5.51 0-10 3.95-10 8.82 0 2.79 1.5 5.29 3.84 6.88v3.22l3.52-1.94c.88.24 1.82.37 2.8.37 5.51 0 10-3.95 10-8.82s-4.49-8.53-10-8.53Zm.79 11.66-2.55-2.73-4.97 2.73 5.46-5.8 2.6 2.73 4.93-2.73-5.47 5.8Z"/></svg>
+          <span class="links-button__text">
+            <span class="links-button__title">Kanał Messenger</span>
+            <span class="links-button__handle">ExploRideURBEX</span>
+          </span>
         </a>
       </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -972,48 +972,61 @@
     .links-buttons {
       width: 100%;
       display: flex;
-      flex-direction: column;
-      align-items: stretch;
-      justify-content: flex-start;
+      flex-wrap: wrap;
+      justify-content: center;
       gap: clamp(14px, 3vw, 24px);
       font-family: 'BebasNeue', 'Base02', Arial, Helvetica, sans-serif;
     }
 
     .links-buttons .links-button {
-      display: flex;
-      width: 100%;
-      flex-direction: column;
-      align-items: center;
-      gap: clamp(6px, 1.4vw, 12px);
-      padding: clamp(16px, 3.6vw, 24px) clamp(18px, 4.6vw, 30px);
-      border: 1px solid rgba(255, 255, 255, 0.12);
-      box-shadow: 0 14px 30px rgba(0, 0, 0, 0.35);
-      white-space: normal;
-      text-align: center;
-      transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+      min-width: clamp(220px, 32vw, 260px);
+      color: rgb(0 0 0);
+      text-transform: none;
+      line-height: 1.2;
     }
 
-    .links-buttons .links-button:hover,
-    .links-buttons .links-button:focus-visible {
-      transform: translateY(-2px);
-      box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+    .links-button__icon {
+      flex-shrink: 0;
+      width: 1.3em;
+      height: 1.3em;
+    }
+
+    .links-button__text {
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+      align-items: flex-start;
+      text-align: left;
+      line-height: 1.1;
     }
 
     .links-button__title {
-      font-size: clamp(1.2rem, 3.4vw, 1.6rem);
-      letter-spacing: clamp(1.2px, 0.5vw, 3px);
+      font-size: clamp(1.05rem, 2.6vw, 1.28rem);
+      letter-spacing: 0.08em;
       text-transform: uppercase;
     }
 
     .links-button__handle {
-      font-size: clamp(0.85rem, 2.4vw, 1rem);
-      opacity: 0.85;
+      font-family: 'Base02', Arial, Helvetica, sans-serif;
+      font-size: clamp(0.78rem, 2.2vw, 0.95rem);
       letter-spacing: normal;
+      opacity: 0.7;
     }
 
-    @media (max-width: 600px) {
-      .links-buttons .links-button {
-        min-width: 100%;
+    .links-button--pinterest,
+    .links-button--ig-channel,
+    .links-button--messenger {
+      background: #d9d9d9;
+    }
+
+    @media (max-width: 520px) {
+      .links-buttons {
+        justify-content: center;
+      }
+
+      .links-button__text {
+        align-items: center;
+        text-align: center;
       }
     }
 


### PR DESCRIPTION
## Summary
- restyle the Linki page buttons to reuse the homepage social button look and add matching icons
- adjust the Linki styles so handles display beneath the labels while keeping the shared button layout

## Testing
- Manual verification in the browser

------
https://chatgpt.com/codex/tasks/task_e_68e4f3b54fd88330952a2ac5a7432126