### PR TITLE
Reorder support options on support page

### DIFF
--- a/wesprzyj-nas.html
+++ b/wesprzyj-nas.html
@@ -48,6 +48,85 @@
       </div>
 
       <section class="support-section">
+        <h2 class="support-heading">Formy wsparcia</h2>
+        <ul class="support-options">
+          <li>
+            <a class="support-option" href="https://buycoffee.to/exploride" target="_blank" rel="noopener noreferrer">
+              <span class="brand-icon brand-icon--lg brand-icon--buycoffee" aria-hidden="true">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                  <path d="M5 7h11a2 2 0 0 1 2 2v1.5a3.5 3.5 0 0 1-3.2 3.5L13.9 19a2.2 2.2 0 0 1-2.2 1.9H9.3a2.2 2.2 0 0 1-2.2-1.9L6.1 14H5a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2z" fill="currentColor"></path>
+                  <path d="M16 9h2.2a2 2 0 0 1 0 4H16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"></path>
+                  <path d="M9 4.6c.7 0 1.3.6 1.3 1.3 0 .5-.2.9-.5 1.1M12 4.3c.7 0 1.3.6 1.3 1.3 0 .5-.2.8-.5 1" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"></path>
+                </svg>
+              </span>
+              <span class="support-option-content">
+                <span class="support-option-name">BuyCoffee</span>
+                <span class="support-option-desc">Postaw nam kawę i wesprzyj wyprawy.</span>
+              </span>
+            </a>
+          </li>
+          <li>
+            <a class="support-option" href="https://www.youtube.com/channel/UCDDh55aHt6hRAjIu5BIkrUQ/join" target="_blank" rel="noopener noreferrer">
+              <span class="brand-icon brand-icon--lg brand-icon--youtube" aria-hidden="true">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                  <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" fill="currentColor"></path>
+                </svg>
+              </span>
+              <span class="support-option-content">
+                <span class="support-option-name">YouTube</span>
+                <span class="support-option-desc">Dołącz do członkostwa kanału.</span>
+              </span>
+            </a>
+          </li>
+          <li>
+            <a class="support-option" href="https://www.facebook.com/ExploRideURBEX/subscribe/" target="_blank" rel="noopener noreferrer">
+              <span class="brand-icon brand-icon--lg brand-icon--facebook" aria-hidden="true">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                  <path d="M9.101 23.691v-7.98H6.627v-3.667h2.474v-1.58c0-4.085 1.848-5.978 5.858-5.978.401 0 .955.042 1.468.103a8.68 8.68 0 0 1 1.141.195v3.325a8.623 8.623 0 0 0-.653-.036 26.805 26.805 0 0 0-.733-.009c-.707 0-1.259.096-1.675.309a1.686 1.686 0 0 0-.679.622c-.258.42-.374.995-.374 1.752v1.297h3.919l-.386 2.103-.287 1.564h-3.246v8.245C19.396 23.238 24 18.179 24 12.044c0-6.627-5.373-12-12-12S0 5.373 0 12c0 5.628 3.874 10.35 9.101 11.647Z" fill="currentColor"></path>
+                </svg>
+              </span>
+              <span class="support-option-content">
+                <span class="support-option-name">Facebook</span>
+                <span class="support-option-desc">Włącz subskrypcję wspierających.</span>
+              </span>
+            </a>
+          </li>
+          <li>
+            <a class="support-option" href="https://paypal.me/EXPLORIDE" target="_blank" rel="noopener noreferrer">
+              <span class="brand-icon brand-icon--lg brand-icon--paypal" aria-hidden="true">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                  <path d="M9.4 5.4h4.5c2.2 0 3.7 1.2 3.7 3.1 0 2.2-1.9 3.6-4.5 3.6h-2l-.9 5.5H7.6l1.8-12.2z" fill="currentColor"></path>
+                  <path d="M14.9 8.2h1.8c1 0 1.6.5 1.6 1.5 0 1.1-.9 1.7-2.1 1.7h-1.7z" fill="currentColor" opacity="0.55"></path>
+                </svg>
+              </span>
+              <span class="support-option-content">
+                <span class="support-option-name">PayPal</span>
+                <span class="support-option-desc">Wyślij jednorazowe lub cykliczne wsparcie.</span>
+              </span>
+            </a>
+          </li>
+          <li>
+            <div class="support-option support-option--static">
+              <span class="brand-icon brand-icon--lg brand-icon--bank" aria-hidden="true">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                  <path d="M4 9.3 12 4l8 5.3v1.4H4z" fill="currentColor"></path>
+                  <rect x="5" y="11.2" width="14" height="7.6" rx="1.3" fill="currentColor" opacity="0.75"></rect>
+                  <rect x="7" y="12.8" width="2.4" height="4.2" fill="currentColor"></rect>
+                  <rect x="11" y="12.8" width="2.4" height="4.2" fill="currentColor"></rect>
+                  <rect x="15" y="12.8" width="2.4" height="4.2" fill="currentColor"></rect>
+                  <rect x="4" y="19.2" width="16" height="1.6" fill="currentColor"></rect>
+                </svg>
+              </span>
+              <span class="support-option-content">
+                <span class="support-option-name">Przelew bankowy</span>
+                <span class="support-option-note">76 1050 1894 1000 0097 2209 8382</span>
+              </span>
+            </div>
+          </li>
+        </ul>
+      </section>
+
+      <section class="support-section">
         <h2 class="support-heading">Twoje wsparcie pomaga nam:</h2>
         <ul class="support-list">
           <li>
@@ -144,85 +223,6 @@
               </svg>
             </span>
             <span>dostęp do tajnych grup społeczności</span>
-          </li>
-        </ul>
-      </section>
-
-      <section class="support-section">
-        <h2 class="support-heading">Formy wsparcia</h2>
-        <ul class="support-options">
-          <li>
-            <a class="support-option" href="https://buycoffee.to/exploride" target="_blank" rel="noopener noreferrer">
-              <span class="brand-icon brand-icon--lg brand-icon--buycoffee" aria-hidden="true">
-                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
-                  <path d="M5 7h11a2 2 0 0 1 2 2v1.5a3.5 3.5 0 0 1-3.2 3.5L13.9 19a2.2 2.2 0 0 1-2.2 1.9H9.3a2.2 2.2 0 0 1-2.2-1.9L6.1 14H5a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2z" fill="currentColor"></path>
-                  <path d="M16 9h2.2a2 2 0 0 1 0 4H16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"></path>
-                  <path d="M9 4.6c.7 0 1.3.6 1.3 1.3 0 .5-.2.9-.5 1.1M12 4.3c.7 0 1.3.6 1.3 1.3 0 .5-.2.8-.5 1" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"></path>
-                </svg>
-              </span>
-              <span class="support-option-content">
-                <span class="support-option-name">BuyCoffee</span>
-                <span class="support-option-desc">Postaw nam kawę i wesprzyj wyprawy.</span>
-              </span>
-            </a>
-          </li>
-          <li>
-            <a class="support-option" href="https://www.youtube.com/channel/UCDDh55aHt6hRAjIu5BIkrUQ/join" target="_blank" rel="noopener noreferrer">
-              <span class="brand-icon brand-icon--lg brand-icon--youtube" aria-hidden="true">
-                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
-                  <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" fill="currentColor"></path>
-                </svg>
-              </span>
-              <span class="support-option-content">
-                <span class="support-option-name">YouTube</span>
-                <span class="support-option-desc">Dołącz do członkostwa kanału.</span>
-              </span>
-            </a>
-          </li>
-          <li>
-            <a class="support-option" href="https://www.facebook.com/ExploRideURBEX/subscribe/" target="_blank" rel="noopener noreferrer">
-              <span class="brand-icon brand-icon--lg brand-icon--facebook" aria-hidden="true">
-                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
-                  <path d="M9.101 23.691v-7.98H6.627v-3.667h2.474v-1.58c0-4.085 1.848-5.978 5.858-5.978.401 0 .955.042 1.468.103a8.68 8.68 0 0 1 1.141.195v3.325a8.623 8.623 0 0 0-.653-.036 26.805 26.805 0 0 0-.733-.009c-.707 0-1.259.096-1.675.309a1.686 1.686 0 0 0-.679.622c-.258.42-.374.995-.374 1.752v1.297h3.919l-.386 2.103-.287 1.564h-3.246v8.245C19.396 23.238 24 18.179 24 12.044c0-6.627-5.373-12-12-12S0 5.373 0 12c0 5.628 3.874 10.35 9.101 11.647Z" fill="currentColor"></path>
-                </svg>
-              </span>
-              <span class="support-option-content">
-                <span class="support-option-name">Facebook</span>
-                <span class="support-option-desc">Włącz subskrypcję wspierających.</span>
-              </span>
-            </a>
-          </li>
-          <li>
-            <a class="support-option" href="https://paypal.me/EXPLORIDE" target="_blank" rel="noopener noreferrer">
-              <span class="brand-icon brand-icon--lg brand-icon--paypal" aria-hidden="true">
-                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
-                  <path d="M9.4 5.4h4.5c2.2 0 3.7 1.2 3.7 3.1 0 2.2-1.9 3.6-4.5 3.6h-2l-.9 5.5H7.6l1.8-12.2z" fill="currentColor"></path>
-                  <path d="M14.9 8.2h1.8c1 0 1.6.5 1.6 1.5 0 1.1-.9 1.7-2.1 1.7h-1.7z" fill="currentColor" opacity="0.55"></path>
-                </svg>
-              </span>
-              <span class="support-option-content">
-                <span class="support-option-name">PayPal</span>
-                <span class="support-option-desc">Wyślij jednorazowe lub cykliczne wsparcie.</span>
-              </span>
-            </a>
-          </li>
-          <li>
-            <div class="support-option support-option--static">
-              <span class="brand-icon brand-icon--lg brand-icon--bank" aria-hidden="true">
-                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
-                  <path d="M4 9.3 12 4l8 5.3v1.4H4z" fill="currentColor"></path>
-                  <rect x="5" y="11.2" width="14" height="7.6" rx="1.3" fill="currentColor" opacity="0.75"></rect>
-                  <rect x="7" y="12.8" width="2.4" height="4.2" fill="currentColor"></rect>
-                  <rect x="11" y="12.8" width="2.4" height="4.2" fill="currentColor"></rect>
-                  <rect x="15" y="12.8" width="2.4" height="4.2" fill="currentColor"></rect>
-                  <rect x="4" y="19.2" width="16" height="1.6" fill="currentColor"></rect>
-                </svg>
-              </span>
-              <span class="support-option-content">
-                <span class="support-option-name">Przelew bankowy</span>
-                <span class="support-option-note">76 1050 1894 1000 0097 2209 8382</span>
-              </span>
-            </div>
           </li>
         </ul>
       </section>


### PR DESCRIPTION
## Summary
- move the support option buttons higher on the support page so they appear before the benefits sections

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68e4f634f0048330ae7ab28311c5fe66