### PR TITLE
Convert site navigation into a fixed left sidebar

### DIFF
--- a/filmy.html
+++ b/filmy.html
@@ -15,7 +15,7 @@
   </script>
 </head>
 <body class="page-videos">
-  <header>
+  <header data-nav-layout="sidebar">
     <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
       <span class="brand-name">EXPLORIDE.PL</span>

--- a/galeria.html
+++ b/galeria.html
@@ -15,7 +15,7 @@
   </script>
 </head>
 <body class="page-gallery">
-  <header>
+  <header data-nav-layout="sidebar">
     <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
       <span class="brand-name">EXPLORIDE.PL</span>

--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
     </script>
   </head>
 <body class="page-home">
-  <header>
+  <header data-nav-layout="sidebar">
     <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
       <span class="brand-name">EXPLORIDE.PL</span>

--- a/kontakt.html
+++ b/kontakt.html
@@ -15,7 +15,7 @@
   </script>
 </head>
 <body class="page-contact">
-  <header>
+  <header data-nav-layout="sidebar">
     <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
       <span class="brand-name">EXPLORIDE.PL</span>

--- a/linki.html
+++ b/linki.html
@@ -16,7 +16,7 @@
   </script>
 </head>
 <body class="page-links">
-  <header>
+  <header data-nav-layout="sidebar">
     <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
       <span class="brand-name">EXPLORIDE.PL</span>

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 (function () {
   function initNavToggle() {
     const header = document.querySelector('header');
-    if (!header) {
+    if (!header || header.dataset.navLayout === 'sidebar') {
       return;
     }
 

--- a/materialy.html
+++ b/materialy.html
@@ -15,7 +15,7 @@
   </script>
 </head>
 <body class="page-downloads">
-  <header>
+  <header data-nav-layout="sidebar">
     <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
       <span class="brand-name">EXPLORIDE.PL</span>

--- a/onas.html
+++ b/onas.html
@@ -15,7 +15,7 @@
   </script>
 </head>
 <body class="page-about">
-  <header>
+  <header data-nav-layout="sidebar">
     <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
       <span class="brand-name">EXPLORIDE.PL</span>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -15,7 +15,7 @@
   </script>
 </head>
 <body class="page-privacy">
-  <header>
+  <header data-nav-layout="sidebar">
     <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
       <span class="brand-name">EXPLORIDE.PL</span>

--- a/style.css
+++ b/style.css
@@ -17,10 +17,13 @@
    :root {
       --background-cycle-duration: 12000ms;
       --background-fade-duration: 1200ms;
+      --sidebar-width: clamp(240px, 24vw, 320px);
     }
    body {
       height: 100%;
+      min-height: 100vh;
       margin: 0;
+      padding-left: calc(var(--sidebar-width) + clamp(16px, 4vw, 40px));
       background: #111 url('backgrounds/background1.jpg') no-repeat center center;
       background-size: 130% auto;
       color: #fff;
@@ -96,16 +99,23 @@
     header {
           background: #000000c2;
       color: #fff;
-      padding: clamp(24px, 6vw, 40px) 16px clamp(32px, 8vw, 52px);
+      padding: clamp(28px, 6vw, 48px) clamp(18px, 4vw, 28px);
+      width: var(--sidebar-width);
+      height: 100vh;
+      position: fixed;
+      inset: 0 auto 0 0;
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: clamp(18px, 5vw, 32px);
-      margin-bottom: 50px;
-      box-shadow: 0 0 20px 6px #000;
+      justify-content: flex-start;
+      gap: clamp(18px, 5vw, 36px);
+      margin: 0;
+      box-shadow: 6px 0 30px rgba(0, 0, 0, 0.6);
       text-align: center;
-      position: relative;
       overflow: hidden;
+      overflow-y: auto;
+      z-index: 10;
+      scrollbar-gutter: stable;
     }
 
   header::before {
@@ -201,18 +211,19 @@
     }
     .top-nav {
       display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      align-content: center;
-      column-gap: clamp(10px, 2.2vw, 20px);
-      row-gap: clamp(8px, 2vw, 16px);
+      flex-direction: column;
+      align-items: stretch;
+      justify-content: flex-start;
+      gap: clamp(10px, 2.2vw, 20px);
+      width: 100%;
       font-family: 'BebasNeue', 'Base02', Arial, Helvetica, sans-serif;
+      margin-top: clamp(12px, 3vw, 28px);
     }
     .nav-link {
       display: inline-flex;
       align-items: center;
-      justify-content: center;
-      padding: clamp(8px, 1.6vw, 14px) clamp(16px, 3vw, 24px);
+      justify-content: flex-start;
+      padding: clamp(10px, 1.6vw, 16px) clamp(18px, 3vw, 26px);
       border-radius: 999px;
       border: 1px solid rgba(255, 255, 255, 0.12);
       background: rgb(52, 52, 52);
@@ -222,6 +233,8 @@
       cursor: pointer;
       white-space: nowrap;
       letter-spacing: clamp(2px, 0.6vw, 4px);
+      width: 100%;
+      text-align: left;
     }
     a.nav-link { text-decoration: none; }
     button.nav-link {
@@ -272,58 +285,31 @@
       color: #fff;
     }
     @media (max-width: 767px) {
+      :root {
+        --sidebar-width: min(240px, 60vw);
+      }
+      body {
+        padding-left: calc(var(--sidebar-width) + clamp(12px, 6vw, 20px));
+      }
       header {
-        align-items: center;
+        padding: clamp(24px, 8vw, 36px) clamp(16px, 6vw, 24px);
+        align-items: flex-start;
       }
-      .nav-toggle {
-        display: inline-flex;
-        align-self: center;
+      .brand {
+        align-items: flex-start;
+        text-align: left;
+        width: 100%;
       }
       .top-nav {
-        --top-nav-expanded-height: 75vh;
-        position: relative;
-        flex-direction: column;
-        flex-wrap: nowrap;
-        align-items: stretch;
-        width: min(520px, 100%);
-        gap: 12px;
-        padding-top: 12px;
-        margin-top: 8px;
-        border-top: 1px solid rgba(255, 255, 255, 0.12);
-        background: transparent;
-        overflow: hidden;
-        max-height: 0;
-        opacity: 0;
-        visibility: hidden;
-        pointer-events: none;
-        transform: translateY(-8px);
-        transition:
-          max-height 220ms cubic-bezier(0.4, 0, 0.2, 1),
-          opacity 140ms ease,
-          transform 200ms ease;
+        gap: clamp(12px, 4vw, 18px);
       }
-      header.is-nav-open .top-nav {
-        max-height: var(--top-nav-expanded-height);
-        opacity: 1;
-        visibility: visible;
-        pointer-events: auto;
-        transform: translateY(0);
-      }
-      .top-nav .nav-link { width: 100%; }
-    }
-    @media (max-width: 767px) and (prefers-reduced-motion: reduce) {
-      .top-nav {
-        transition: none;
-        transform: none;
+      .nav-link {
+        justify-content: flex-start;
       }
     }
     @media (min-width: 768px) {
-      header {
-        padding-left: clamp(32px, 8vw, 80px);
-        padding-right: clamp(32px, 8vw, 80px);
-      }
       .top-nav {
-        justify-content: center;
+        justify-content: flex-start;
       }
     }
     h2 {

--- a/wesprzyj-nas.html
+++ b/wesprzyj-nas.html
@@ -15,7 +15,7 @@
   </script>
 </head>
 <body class="page-support">
-  <header>
+  <header data-nav-layout="sidebar">
     <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
       <span class="brand-name">EXPLORIDE.PL</span>


### PR DESCRIPTION
## Summary
- restyled the shared header so that branding and navigation render as a fixed full-height sidebar on the left
- tagged each page header with a sidebar layout flag and taught the nav toggle script to skip collapsing this layout

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e6557ea0588330bb80ed25dfc01dc5