### PR TITLE
Ujednolicenie nagłówka na podstronach

### DIFF
--- a/filmy.html
+++ b/filmy.html
@@ -18,7 +18,6 @@
   <header data-nav-layout="sidebar">
     <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
-      <span class="brand-name">EXPLORIDE.PL</span>
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
       <span class="nav-toggle__bars" aria-hidden="true">

--- a/galeria.html
+++ b/galeria.html
@@ -18,7 +18,6 @@
   <header data-nav-layout="sidebar">
     <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
-      <span class="brand-name">EXPLORIDE.PL</span>
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
       <span class="nav-toggle__bars" aria-hidden="true">

--- a/kontakt.html
+++ b/kontakt.html
@@ -18,7 +18,6 @@
   <header data-nav-layout="sidebar">
     <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
-      <span class="brand-name">EXPLORIDE.PL</span>
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
       <span class="nav-toggle__bars" aria-hidden="true">

--- a/linki.html
+++ b/linki.html
@@ -19,7 +19,6 @@
   <header data-nav-layout="sidebar">
     <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
-      <span class="brand-name">EXPLORIDE.PL</span>
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
       <span class="nav-toggle__bars" aria-hidden="true">

--- a/materialy.html
+++ b/materialy.html
@@ -18,7 +18,6 @@
   <header data-nav-layout="sidebar">
     <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
-      <span class="brand-name">EXPLORIDE.PL</span>
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
       <span class="nav-toggle__bars" aria-hidden="true">

--- a/onas.html
+++ b/onas.html
@@ -18,7 +18,6 @@
   <header data-nav-layout="sidebar">
     <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
-      <span class="brand-name">EXPLORIDE.PL</span>
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
       <span class="nav-toggle__bars" aria-hidden="true">

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -18,7 +18,6 @@
   <header data-nav-layout="sidebar">
     <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
-      <span class="brand-name">EXPLORIDE.PL</span>
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
       <span class="nav-toggle__bars" aria-hidden="true">

--- a/style.css
+++ b/style.css
@@ -147,21 +147,7 @@
     }
     .brand:hover,
     .brand:focus-visible { color: #e50914; }
-    .brand-name {
-      font-family: 'BebasNeue', Arial, Helvetica, sans-serif !important;
-      font-weight: 400 !important;
-      letter-spacing: clamp(3px, 0.7vw, 8px);
-      font-size: clamp(2.2rem, 6vw, 3.8rem);
-      text-transform: uppercase;
-      line-height: 1;
-      max-width: 100%;
-      word-break: break-word;
-    }
-
     header .logo {
-      display: none;
-    }
-    .page-home header .logo {
       display: block;
       width: clamp(88px, 12vw, 128px);
       height: auto;

--- a/wesprzyj-nas.html
+++ b/wesprzyj-nas.html
@@ -18,7 +18,6 @@
   <header data-nav-layout="sidebar">
     <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
-      <span class="brand-name">EXPLORIDE.PL</span>
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
       <span class="nav-toggle__bars" aria-hidden="true">


### PR DESCRIPTION
## Summary
- usunięto tekstowy napis z sekcji brand na podstronach, pozostawiając logo jak na stronie głównej
- zmodyfikowano style nagłówka, aby wyświetlał graficzne logo na wszystkich podstronach i posprzątano zbędne reguły

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e6643b7f4c8330ad8aca2ae6ce05fd