### PR TITLE
Filter YouTube playlist tiles to show only public embeddable videos

### DIFF
--- a/filmy.html
+++ b/filmy.html
@@ -271,6 +271,45 @@
       return `${day}.${m}.${y}`;
     }
 
+
+    async function fetchPublicVideoDetails(videoIds) {
+      const ids = Array.from(new Set((videoIds || []).filter(Boolean)));
+      const map = new Map();
+      if (ids.length === 0) return map;
+
+      const base = "https://www.googleapis.com/youtube/v3/videos";
+      for (let i = 0; i < ids.length; i += 50) {
+        const chunk = ids.slice(i, i + 50);
+        const url = new URL(base);
+        url.searchParams.set("part", "snippet,status,contentDetails");
+        url.searchParams.set("id", chunk.join(","));
+        url.searchParams.set("key", API_KEY);
+
+        const res = await fetch(url.toString());
+        if (!res.ok) throw new Error("HTTP " + res.status);
+        const data = await res.json();
+        const items = Array.isArray(data.items) ? data.items : [];
+
+        items.forEach(item => {
+          const id = item?.id;
+          const privacyStatus = item?.status?.privacyStatus;
+          const embeddable = item?.status?.embeddable;
+          if (!id) return;
+          if (privacyStatus !== "public") return;
+          if (embeddable === false) return;
+
+          map.set(id, {
+            id,
+            title: item?.snippet?.title || "Bez tytułu",
+            publishedAtISO: toISOorNull(item?.snippet?.publishedAt),
+            thumb: item?.snippet?.thumbnails?.medium?.url || item?.snippet?.thumbnails?.high?.url || ""
+          });
+        });
+      }
+
+      return map;
+    }
+
     async function fetchAllPlaylistItems(playlistId) {
       const base = "https://www.googleapis.com/youtube/v3/playlistItems";
       let pageToken = "";
@@ -290,18 +329,16 @@
         pageToken = data.nextPageToken || "";
       } while (pageToken);
 
-      return all.map(item => {
-        const vid = item.snippet?.resourceId?.videoId || item.contentDetails?.videoId || "";
-        const iso = toISOorNull(item.contentDetails?.videoPublishedAt || item.snippet?.publishedAt);
-        return {
-          id: vid,
-          title: item.snippet?.title || "Bez tytułu",
-          publishedAtISO: iso,
-          thumb: item.snippet?.thumbnails?.medium?.url || item.snippet?.thumbnails?.high?.url || ""
-        };
-      });
-    }
+      const playlistVideoIds = all
+        .map(item => item.snippet?.resourceId?.videoId || item.contentDetails?.videoId || "")
+        .filter(Boolean);
 
+      const publicVideos = await fetchPublicVideoDetails(playlistVideoIds);
+
+      return playlistVideoIds
+        .map(id => publicVideos.get(id))
+        .filter(Boolean);
+    }
     function setupPlaylistSection(config) {
       const loader = document.getElementById(config.loaderId);
       const fallback = document.getElementById(config.fallbackId);

--- a/index.html
+++ b/index.html
@@ -1063,6 +1063,45 @@ document.addEventListener('DOMContentLoaded', () => {
       return `${day}.${m}.${y}`;
     }
 
+
+    async function fetchPublicVideoDetails(videoIds) {
+      const ids = Array.from(new Set((videoIds || []).filter(Boolean)));
+      const map = new Map();
+      if (ids.length === 0) return map;
+
+      const base = "https://www.googleapis.com/youtube/v3/videos";
+      for (let i = 0; i < ids.length; i += 50) {
+        const chunk = ids.slice(i, i + 50);
+        const url = new URL(base);
+        url.searchParams.set("part", "snippet,status,contentDetails");
+        url.searchParams.set("id", chunk.join(","));
+        url.searchParams.set("key", API_KEY);
+
+        const res = await fetch(url.toString());
+        if (!res.ok) throw new Error("HTTP " + res.status);
+        const data = await res.json();
+        const items = Array.isArray(data.items) ? data.items : [];
+
+        items.forEach(item => {
+          const id = item?.id;
+          const privacyStatus = item?.status?.privacyStatus;
+          const embeddable = item?.status?.embeddable;
+          if (!id) return;
+          if (privacyStatus !== "public") return;
+          if (embeddable === false) return;
+
+          map.set(id, {
+            id,
+            title: item?.snippet?.title || "Bez tytułu",
+            publishedAtISO: toISOorNull(item?.snippet?.publishedAt),
+            thumb: item?.snippet?.thumbnails?.medium?.url || item?.snippet?.thumbnails?.high?.url || ""
+          });
+        });
+      }
+
+      return map;
+    }
+
     async function fetchAllPlaylistItems(playlistId) {
       const base = "https://www.googleapis.com/youtube/v3/playlistItems";
       let pageToken = "";
@@ -1082,18 +1121,16 @@ document.addEventListener('DOMContentLoaded', () => {
         pageToken = data.nextPageToken || "";
       } while (pageToken);
 
-      return all.map(item => {
-        const vid = item.snippet?.resourceId?.videoId || item.contentDetails?.videoId || "";
-        const iso = toISOorNull(item.contentDetails?.videoPublishedAt || item.snippet?.publishedAt);
-        return {
-          id: vid,
-          title: item.snippet?.title || "Bez tytułu",
-          publishedAtISO: iso,
-          thumb: item.snippet?.thumbnails?.medium?.url || item.snippet?.thumbnails?.high?.url || ""
-        };
-      });
-    }
+      const playlistVideoIds = all
+        .map(item => item.snippet?.resourceId?.videoId || item.contentDetails?.videoId || "")
+        .filter(Boolean);
 
+      const publicVideos = await fetchPublicVideoDetails(playlistVideoIds);
+
+      return playlistVideoIds
+        .map(id => publicVideos.get(id))
+        .filter(Boolean);
+    }
     function setupPlaylistSection(config) {
       const onLatestVideo = typeof config.onLatestVideo === "function" ? config.onLatestVideo : null;
       const onFallback = typeof config.onFallback === "function" ? config.onFallback : null;


### PR DESCRIPTION
### Motivation
- Playlist tiles currently include removed/private/unavailable videos because `playlistItems` can list items even when the video is not public or embeddable.
- The goal is to display only existing public videos and keep existing UI, ordering and fallback behavior unchanged.

### Description
- Added `fetchPublicVideoDetails(videoIds)` in both `index.html` and `filmy.html` which batches IDs (max 50), queries `youtube/v3/videos` with `part=snippet,status,contentDetails`, and returns only videos that exist, have `status.privacyStatus === "public"` and are not explicitly non-embeddable (`embeddable !== false`).
- Updated `fetchAllPlaylistItems(playlistId)` to fetch all `playlistItems`, extract `videoId`s in playlist order, call `fetchPublicVideoDetails(...)`, and return only verified videos built from `videos.snippet` (title/publishedAt/thumbnail).
- The filtering logic is shared and therefore applies to both playlist sections defined in `PLAYLIST_SECTIONS` (`urbex` and `travel`) without changing layout/CSS or downstream UI logic (including hide-latest and fallback behavior).
- Kept existing error paths so the previous fallback behaviour remains in place if the YouTube API calls fail.

### Testing
- No unit/integration automated tests exist for this frontend snippet, so no automated tests were run.
- Performed repository sanity checks including `git diff` to review changes and `git commit` to record the update, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05cbad32788330be489550a5fd94bb)