### PR TITLE
Replace cart details iframe with HTML inquiry form

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -67,6 +67,42 @@
     return { totalItems, totalPrice };
   };
 
+
+  const ORDER_ENDPOINT = 'https://script.google.com/macros/s/AKfycbz4Rm1C4vFTRam9ESDoKe2w-RbyTTXGFQq-Go8MQQ6VCPJYz4kQF-Ti6HfFEAErgabu/exec';
+
+  const buildOrderItems = () => cart.map((item) => {
+    const product = PRODUCTS[item.id];
+    if (!product) return null;
+    const quantity = Math.max(1, Number(item.quantity) || 1);
+    const price = product.price;
+    return {
+      name: product.name,
+      variant: item.size || '',
+      quantity,
+      price,
+      sum: Number((price * quantity).toFixed(2))
+    };
+  }).filter(Boolean);
+
+  const submitOrderRequest = async (payload) => {
+    try {
+      const response = await fetch(ORDER_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      return response.ok;
+    } catch (error) {
+      await fetch(ORDER_ENDPOINT, {
+        method: 'POST',
+        mode: 'no-cors',
+        headers: { 'Content-Type': 'text/plain;charset=utf-8' },
+        body: JSON.stringify(payload)
+      });
+      return true;
+    }
+  };
+
   const updateSummaryUI = () => {
     const { totalItems, totalPrice } = getCartSummary();
     document.querySelectorAll('[data-cart-count]').forEach((node) => {
@@ -310,9 +346,41 @@
 
     const continueBtn = modal.querySelector('[data-cart-to-payment]');
     if (continueBtn) {
-      continueBtn.addEventListener('click', () => {
-        modal.dataset.step = 'payment';
-        updateStepUI();
+      continueBtn.addEventListener('click', async () => {
+        const form = modal.querySelector('[data-cart-details-form]');
+        const status = modal.querySelector('[data-cart-form-status]');
+        if (!form) return;
+
+        if (!cart.length) {
+          if (status) status.textContent = 'Koszyk jest pusty.';
+          return;
+        }
+
+        if (!form.reportValidity()) return;
+
+        const formData = new FormData(form);
+        const payload = {
+          customerName: String(formData.get('customerName') || '').trim(),
+          customerEmail: String(formData.get('customerEmail') || '').trim(),
+          customerPhone: String(formData.get('customerPhone') || '').trim(),
+          message: String(formData.get('message') || '').trim(),
+          items: buildOrderItems(),
+          total: Number(calculateTotal(cart).toFixed(2))
+        };
+
+        continueBtn.disabled = true;
+        if (status) status.textContent = 'Wysyłanie zapytania…';
+
+        try {
+          const sent = await submitOrderRequest(payload);
+          if (!sent) throw new Error('Nie udało się wysłać zapytania.');
+          if (status) status.textContent = 'Zapytanie wysłane. Odezwę się mailowo w celu finalizacji.';
+          form.reset();
+        } catch (error) {
+          if (status) status.textContent = 'Nie udało się wysłać zapytania. Spróbuj ponownie za chwilę.';
+        } finally {
+          continueBtn.disabled = false;
+        }
       });
     }
 

--- a/sklep/czapka-z-daszkiem-exploride.html
+++ b/sklep/czapka-z-daszkiem-exploride.html
@@ -149,10 +149,28 @@
             <button class="button button--ghost" type="button" data-step-back="cart">← Wróć</button>
           </div>
           <div class="form-embed">
-            <iframe title="Formularz zamówienia" src="https://docs.google.com/forms/d/e/1FAIpQLSchrDf1w9wuA-92sdK02fenQZ1C4OMrmEQKWEIKcN4Rjha4Hg/viewform?embedded=true" allowfullscreen loading="lazy"></iframe>
+            <form class="cart-details-form" data-cart-details-form>
+              <label class="cart-details-form__field">
+                <span>Imię i nazwisko *</span>
+                <input type="text" name="customerName" required autocomplete="name">
+              </label>
+              <label class="cart-details-form__field">
+                <span>Email *</span>
+                <input type="email" name="customerEmail" required autocomplete="email">
+              </label>
+              <label class="cart-details-form__field">
+                <span>Telefon</span>
+                <input type="tel" name="customerPhone" autocomplete="tel">
+              </label>
+              <label class="cart-details-form__field">
+                <span>Wiadomość</span>
+                <textarea name="message" rows="4"></textarea>
+              </label>
+              <p class="cart-details-form__status" data-cart-form-status aria-live="polite"></p>
+            </form>
           </div>
           <div class="shop-modal__actions">
-            <button class="button button--primary" type="button" data-cart-to-payment disabled aria-disabled="true">Przejdź do płatności</button>
+            <button class="button button--primary" type="button" data-cart-to-payment>Wyślij zapytanie</button>
           </div>
           <p class="shop-modal__notice">Zamówienie zrealizujesz wypełniając i wysyłając powyższy formularz, a następnie przez korespondencję email. Profesjonalne metody zamówienia i płatności pojawią się w przyszłości.</p>
         </section>

--- a/sklep/index.html
+++ b/sklep/index.html
@@ -108,10 +108,28 @@
             <button class="button button--ghost" type="button" data-step-back="cart">← Wróć</button>
           </div>
           <div class="form-embed">
-            <iframe title="Formularz zamówienia" src="https://docs.google.com/forms/d/e/1FAIpQLSchrDf1w9wuA-92sdK02fenQZ1C4OMrmEQKWEIKcN4Rjha4Hg/viewform?embedded=true" allowfullscreen loading="lazy"></iframe>
+            <form class="cart-details-form" data-cart-details-form>
+              <label class="cart-details-form__field">
+                <span>Imię i nazwisko *</span>
+                <input type="text" name="customerName" required autocomplete="name">
+              </label>
+              <label class="cart-details-form__field">
+                <span>Email *</span>
+                <input type="email" name="customerEmail" required autocomplete="email">
+              </label>
+              <label class="cart-details-form__field">
+                <span>Telefon</span>
+                <input type="tel" name="customerPhone" autocomplete="tel">
+              </label>
+              <label class="cart-details-form__field">
+                <span>Wiadomość</span>
+                <textarea name="message" rows="4"></textarea>
+              </label>
+              <p class="cart-details-form__status" data-cart-form-status aria-live="polite"></p>
+            </form>
           </div>
           <div class="shop-modal__actions">
-            <button class="button button--primary" type="button" data-cart-to-payment disabled aria-disabled="true">Przejdź do płatności</button>
+            <button class="button button--primary" type="button" data-cart-to-payment>Wyślij zapytanie</button>
           </div>
           <p class="shop-modal__notice">Zamówienie zrealizujesz wypełniając i wysyłając powyższy formularz, a następnie przez korespondencję email. Profesjonalne metody zamówienia i płatności pojawią się w przyszłości.</p>
         </section>

--- a/sklep/kalendarz-2026.html
+++ b/sklep/kalendarz-2026.html
@@ -139,10 +139,28 @@
             <button class="button button--ghost" type="button" data-step-back="cart">← Wróć</button>
           </div>
           <div class="form-embed">
-            <iframe title="Formularz zamówienia" src="https://docs.google.com/forms/d/e/1FAIpQLSchrDf1w9wuA-92sdK02fenQZ1C4OMrmEQKWEIKcN4Rjha4Hg/viewform?embedded=true" allowfullscreen loading="lazy"></iframe>
+            <form class="cart-details-form" data-cart-details-form>
+              <label class="cart-details-form__field">
+                <span>Imię i nazwisko *</span>
+                <input type="text" name="customerName" required autocomplete="name">
+              </label>
+              <label class="cart-details-form__field">
+                <span>Email *</span>
+                <input type="email" name="customerEmail" required autocomplete="email">
+              </label>
+              <label class="cart-details-form__field">
+                <span>Telefon</span>
+                <input type="tel" name="customerPhone" autocomplete="tel">
+              </label>
+              <label class="cart-details-form__field">
+                <span>Wiadomość</span>
+                <textarea name="message" rows="4"></textarea>
+              </label>
+              <p class="cart-details-form__status" data-cart-form-status aria-live="polite"></p>
+            </form>
           </div>
           <div class="shop-modal__actions">
-            <button class="button button--primary" type="button" data-cart-to-payment disabled aria-disabled="true">Przejdź do płatności</button>
+            <button class="button button--primary" type="button" data-cart-to-payment>Wyślij zapytanie</button>
           </div>
           <p class="shop-modal__notice">Zamówienie zrealizujesz wypełniając i wysyłając powyższy formularz, a następnie przez korespondencję email. Profesjonalne metody zamówienia i płatności pojawią się w przyszłości.</p>
         </section>

--- a/sklep/t-shirt-damski-classic.html
+++ b/sklep/t-shirt-damski-classic.html
@@ -149,10 +149,28 @@
             <button class="button button--ghost" type="button" data-step-back="cart">← Wróć</button>
           </div>
           <div class="form-embed">
-            <iframe title="Formularz zamówienia" src="https://docs.google.com/forms/d/e/1FAIpQLSchrDf1w9wuA-92sdK02fenQZ1C4OMrmEQKWEIKcN4Rjha4Hg/viewform?embedded=true" allowfullscreen loading="lazy"></iframe>
+            <form class="cart-details-form" data-cart-details-form>
+              <label class="cart-details-form__field">
+                <span>Imię i nazwisko *</span>
+                <input type="text" name="customerName" required autocomplete="name">
+              </label>
+              <label class="cart-details-form__field">
+                <span>Email *</span>
+                <input type="email" name="customerEmail" required autocomplete="email">
+              </label>
+              <label class="cart-details-form__field">
+                <span>Telefon</span>
+                <input type="tel" name="customerPhone" autocomplete="tel">
+              </label>
+              <label class="cart-details-form__field">
+                <span>Wiadomość</span>
+                <textarea name="message" rows="4"></textarea>
+              </label>
+              <p class="cart-details-form__status" data-cart-form-status aria-live="polite"></p>
+            </form>
           </div>
           <div class="shop-modal__actions">
-            <button class="button button--primary" type="button" data-cart-to-payment disabled aria-disabled="true">Przejdź do płatności</button>
+            <button class="button button--primary" type="button" data-cart-to-payment>Wyślij zapytanie</button>
           </div>
           <p class="shop-modal__notice">Zamówienie zrealizujesz wypełniając i wysyłając powyższy formularz, a następnie przez korespondencję email. Profesjonalne metody zamówienia i płatności pojawią się w przyszłości.</p>
         </section>

--- a/sklep/t-shirt-meski-classic.html
+++ b/sklep/t-shirt-meski-classic.html
@@ -149,10 +149,28 @@
             <button class="button button--ghost" type="button" data-step-back="cart">← Wróć</button>
           </div>
           <div class="form-embed">
-            <iframe title="Formularz zamówienia" src="https://docs.google.com/forms/d/e/1FAIpQLSchrDf1w9wuA-92sdK02fenQZ1C4OMrmEQKWEIKcN4Rjha4Hg/viewform?embedded=true" allowfullscreen loading="lazy"></iframe>
+            <form class="cart-details-form" data-cart-details-form>
+              <label class="cart-details-form__field">
+                <span>Imię i nazwisko *</span>
+                <input type="text" name="customerName" required autocomplete="name">
+              </label>
+              <label class="cart-details-form__field">
+                <span>Email *</span>
+                <input type="email" name="customerEmail" required autocomplete="email">
+              </label>
+              <label class="cart-details-form__field">
+                <span>Telefon</span>
+                <input type="tel" name="customerPhone" autocomplete="tel">
+              </label>
+              <label class="cart-details-form__field">
+                <span>Wiadomość</span>
+                <textarea name="message" rows="4"></textarea>
+              </label>
+              <p class="cart-details-form__status" data-cart-form-status aria-live="polite"></p>
+            </form>
           </div>
           <div class="shop-modal__actions">
-            <button class="button button--primary" type="button" data-cart-to-payment disabled aria-disabled="true">Przejdź do płatności</button>
+            <button class="button button--primary" type="button" data-cart-to-payment>Wyślij zapytanie</button>
           </div>
           <p class="shop-modal__notice">Zamówienie zrealizujesz wypełniając i wysyłając powyższy formularz, a następnie przez korespondencję email. Profesjonalne metody zamówienia i płatności pojawią się w przyszłości.</p>
         </section>

--- a/style.css
+++ b/style.css
@@ -3140,12 +3140,40 @@
   line-height: 1.5;
 }
 
-.form-embed iframe {
+.cart-details-form {
+  display: grid;
+  gap: 12px;
+}
+
+.cart-details-form__field {
+  display: grid;
+  gap: 6px;
+}
+
+.cart-details-form__field span {
+  color: #f3f5f7;
+  font-weight: 600;
+}
+
+.cart-details-form__field input,
+.cart-details-form__field textarea {
   width: 100%;
-  border: none;
-  min-height: 520px;
-  border-radius: 14px;
-  background: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.22);
+  color: #fff;
+  padding: 10px 12px;
+  font: inherit;
+}
+
+.cart-details-form__field textarea {
+  resize: vertical;
+}
+
+.cart-details-form__status {
+  margin: 0;
+  min-height: 1.4em;
+  color: #cdd2d6;
 }
 
 .payment-placeholder {


### PR DESCRIPTION
### Motivation
- Replace the embedded Google Forms iframe in the cart `details` step with a native HTML form so the site can collect customer details and cart items directly. 
- Send a structured JSON inquiry to the provided Google Apps Script endpoint instead of opening a payment flow, while keeping existing cart counters and totals intact.

### Description
- Replaced the Google Forms `iframe` with a local form (`<form class="cart-details-form" data-cart-details-form>`) on all shop pages using the modal (`sklep/index.html`, `sklep/kalendarz-2026.html`, `sklep/t-shirt-damski-classic.html`, `sklep/t-shirt-meski-classic.html`, `sklep/czapka-z-daszkiem-exploride.html`) and updated the action button text to `Wyślij zapytanie` (removed `disabled`/`aria-disabled`).
- Added form fields: `customerName` (required), `customerEmail` (required), `customerPhone` (optional), and `message` (optional), and a status node (`data-cart-form-status`), plus CSS styles for `.cart-details-form` in `style.css`.
- Implemented order submission in `shop.js`: added `ORDER_ENDPOINT`, `buildOrderItems()` to derive `items` from current `cart` (name, variant, quantity, price, sum), and `submitOrderRequest(payload)` to POST JSON to the Apps Script URL with a CORS-compatible fallback (`mode: 'no-cors'` + `text/plain`) for GitHub Pages / Apps Script limitations.
- Rewired the `[data-cart-to-payment]` click handler to validate the form, assemble the JSON payload `{ customerName, customerEmail, customerPhone, message, items, total }`, send it, show success text `Zapytanie wysłane. Odezwę się mailowo w celu finalizacji.`, and explicitly avoid transitioning to the `payment` step or invoking any payment provider.

### Testing
- Ran repository searches to confirm replacements: `rg -n "data-cart-step-panel=\"details\"|data-cart-to-payment|cart-details-form|iframe" -S sklep/*.html shop.js` and verified updated lines in the affected files; search succeeded.
- Verified CSS and JS insertions by inspecting file fragments with `nl`/`sed` and confirmed the new handler and `ORDER_ENDPOINT` are present in `shop.js`; inspection succeeded.
- Performed a commit to save changes with `git commit -m "Replace cart details iframe with HTML inquiry form"`, which completed successfully.
- No automated unit or integration tests were present or run for the UI behavior; manual verification steps above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17258d70408330a13fdb77a88fcec8)