### PR TITLE
Fix order submit total calculation in shop cart

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -103,6 +103,15 @@
     }
   };
 
+  const parseDisplayedCurrencyValue = (value) => {
+    const normalized = String(value || '')
+      .replace(/\s/g, '')
+      .replace(/[^\d,.-]/g, '')
+      .replace(',', '.');
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : 0;
+  };
+
   const updateSummaryUI = () => {
     const { totalItems, totalPrice } = getCartSummary();
     document.querySelectorAll('[data-cart-count]').forEach((node) => {
@@ -358,14 +367,28 @@
 
         if (!form.reportValidity()) return;
 
+        const items = buildOrderItems();
+        if (!items.length) {
+          if (status) status.textContent = 'Koszyk jest pusty.';
+          return;
+        }
+
+        const { totalPrice } = getCartSummary();
+        const totalFromState = Number(totalPrice.toFixed(2));
+        const footerTotalNode = modal.querySelector('[data-cart-total-footer]');
+        const headerTotalNode = modal.querySelector('[data-cart-total]');
+        const totalFromUI = Number(
+          parseDisplayedCurrencyValue(footerTotalNode?.textContent || headerTotalNode?.textContent).toFixed(2)
+        );
+
         const formData = new FormData(form);
         const payload = {
           customerName: String(formData.get('customerName') || '').trim(),
           customerEmail: String(formData.get('customerEmail') || '').trim(),
           customerPhone: String(formData.get('customerPhone') || '').trim(),
           message: String(formData.get('message') || '').trim(),
-          items: buildOrderItems(),
-          total: Number(calculateTotal(cart).toFixed(2))
+          items,
+          total: totalFromState > 0 ? totalFromState : totalFromUI
         };
 
         continueBtn.disabled = true;


### PR DESCRIPTION
### Motivation
- Naprawić błąd `ReferenceError: calculateTotal is not defined` przy kliknięciu przycisku `Wyślij zapytanie` i upewnić się, że formularz faktycznie wysyła POST do Google Apps Script. 
- Użyć istniejącego mechanizmu sumowania koszyka zamiast nieistniejącej funkcji `calculateTotal()` oraz dodać bezpieczny fallback na widoczną sumę w UI (`data-cart-total-footer` / `data-cart-total`).

### Description
- Usunięto użycie nieistniejącej funkcji i zmieniono budowę payloadu tak, by wysyłać `items` z funkcji `buildOrderItems()` oraz `total` pochodzące najpierw z `getCartSummary().totalPrice`, a awaryjnie z parsowanego tekstu z selektorów `data-cart-total-footer` lub `data-cart-total` przy użyciu nowej funkcji `parseDisplayedCurrencyValue()`.
- Dodano walidację, że `items` nie są puste przed wysyłką i utrzymano istniejącą kontrolę pustego koszyka oraz `form.reportValidity()`.
- Nie zmieniono logiki dodawania produktów, liczników ani renderowania koszyka; zachowano istniejącą funkcję wysyłki `submitOrderRequest(payload)`.
- Nowe/zmodyfikowane symbole i selektory: `buildOrderItems()`, `getCartSummary()`, `parseDisplayedCurrencyValue()`, `data-cart-total-footer`, `data-cart-total`, `data-cart-to-payment`.

### Testing
- Uruchomiono `node --check shop.js` i plik przeszedł kontrolę składniową pomyślnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1728d245b08330b2b188bcc9b6ac5f)