### PR TITLE
Fix sklep form submit to avoid CORS preflight

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -85,22 +85,14 @@
   }).filter(Boolean);
 
   const submitOrderRequest = async (payload) => {
-    try {
-      const response = await fetch(ORDER_ENDPOINT, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
-      });
-      return response.ok;
-    } catch (error) {
-      await fetch(ORDER_ENDPOINT, {
-        method: 'POST',
-        mode: 'no-cors',
-        headers: { 'Content-Type': 'text/plain;charset=utf-8' },
-        body: JSON.stringify(payload)
-      });
-      return true;
-    }
+    await fetch(ORDER_ENDPOINT, {
+      method: 'POST',
+      mode: 'no-cors',
+      headers: { 'Content-Type': 'text/plain;charset=utf-8' },
+      body: JSON.stringify(payload)
+    });
+
+    return true;
   };
 
   const parseDisplayedCurrencyValue = (value) => {


### PR DESCRIPTION
### Motivation
- Sending `Content-Type: application/json` caused a CORS preflight that Google Apps Script did not allow, so the frontend must send the order in a Apps Script–compatible way without preflight. 

### Description
- Changed `submitOrderRequest` to always `fetch(ORDER_ENDPOINT, { method: 'POST', mode: 'no-cors', headers: { 'Content-Type': 'text/plain;charset=utf-8' }, body: JSON.stringify(payload) })` and return `true` on non-network error. 
- Removed reliance on `response.ok` / reading response body because `mode: 'no-cors'` yields an opaque response. 
- Kept payload as `JSON.stringify(payload)` so Apps Script can continue to use `JSON.parse(e.postData.contents)`. 
- Left server-side / Google Sheets saving behavior unchanged.

### Testing
- Ran `rg -n "submitOrderRequest|Content-Type|no-cors|response\.ok|response\.json" /workspace/site/shop.js` to verify the submission path now uses `no-cors` and `text/plain` and no longer checks `response.ok`, and the check passed. 
- Verified file changes with `git status --short` and committed the change, and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172c0510cc8330ba3e57b252d947e0)