### PR TITLE
Dodanie pola `delivery_address` i obowiązkowej zgody RODO w formularzu zamówienia

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -133,7 +133,7 @@
     return true;
   };
 
-  const sendOrderEmail = async ({ customerName, customerEmail, customerPhone, items, total, message }) => {
+  const sendOrderEmail = async ({ customerName, customerEmail, customerPhone, deliveryAddress, items, total, message }) => {
     const emailjs = await loadEmailJs();
     if (!emailjs || typeof emailjs.send !== 'function') {
       throw new Error('EmailJS nie jest dostępny.');
@@ -146,6 +146,7 @@
         customer_name: customerName,
         customer_email: customerEmail,
         customer_phone: customerPhone,
+        delivery_address: deliveryAddress,
         items,
         total,
         message
@@ -443,9 +444,22 @@
         const status = modal.querySelector('[data-cart-form-status]');
         if (!form) return;
 
+        const gdprConsentField = form.elements.gdprConsent;
+        if (gdprConsentField && !gdprConsentField.dataset.validationBound) {
+          gdprConsentField.addEventListener('change', () => {
+            gdprConsentField.setCustomValidity(gdprConsentField.checked ? '' : 'Musisz zaakceptować zgodę RODO.');
+          });
+          gdprConsentField.dataset.validationBound = 'true';
+        }
+
         if (!cart.length) {
           if (status) status.textContent = 'Koszyk jest pusty.';
           return;
+        }
+
+        const gdprConsentForSubmit = form.elements.gdprConsent;
+        if (gdprConsentForSubmit && 'setCustomValidity' in gdprConsentForSubmit) {
+          gdprConsentForSubmit.setCustomValidity(gdprConsentForSubmit.checked ? '' : 'Musisz zaakceptować zgodę RODO.');
         }
 
         if (!form.reportValidity()) return;
@@ -469,6 +483,7 @@
           customerName: String(formData.get('customerName') || '').trim(),
           customerEmail: String(formData.get('customerEmail') || '').trim(),
           customerPhone: String(formData.get('customerPhone') || '').trim(),
+          delivery_address: String(formData.get('delivery_address') || '').trim(),
           message: String(formData.get('message') || '').trim(),
           items,
           total: totalFromState > 0 ? totalFromState : totalFromUI
@@ -487,6 +502,7 @@
               customerName: payload.customerName,
               customerEmail: payload.customerEmail,
               customerPhone: payload.customerPhone,
+              deliveryAddress: payload.delivery_address,
               items: itemsSummary,
               total: totalSummary,
               message: payload.message

--- a/sklep/index.html
+++ b/sklep/index.html
@@ -121,8 +121,16 @@
                 <input type="tel" name="customerPhone" autocomplete="tel">
               </label>
               <label class="cart-details-form__field">
+                <span>Adres dostawy / kod paczkomatu *</span>
+                <textarea name="delivery_address" rows="3" required placeholder="Wpisz adres dostawy albo kod paczkomatu / punktu odbioru"></textarea>
+              </label>
+              <label class="cart-details-form__field">
                 <span>Wiadomość (opcjonalne)</span>
                 <textarea name="message" rows="4"></textarea>
+              </label>
+              <label class="cart-details-form__checkbox">
+                <input type="checkbox" name="gdprConsent" required>
+                <span>Wyrażam zgodę na przetwarzanie moich danych osobowych w celu obsługi zapytania i realizacji kontaktu zwrotnego. *</span>
               </label>
               <p class="cart-details-form__required-note">* - pola wymagane</p>
               <p class="cart-details-form__status" data-cart-form-status aria-live="polite"></p>

--- a/sklep/kalendarz-2026.html
+++ b/sklep/kalendarz-2026.html
@@ -153,8 +153,16 @@
                 <input type="tel" name="customerPhone" autocomplete="tel">
               </label>
               <label class="cart-details-form__field">
+                <span>Adres dostawy / kod paczkomatu *</span>
+                <textarea name="delivery_address" rows="3" required placeholder="Wpisz adres dostawy albo kod paczkomatu / punktu odbioru"></textarea>
+              </label>
+              <label class="cart-details-form__field">
                 <span>Wiadomość (opcjonalne)</span>
                 <textarea name="message" rows="4"></textarea>
+              </label>
+              <label class="cart-details-form__checkbox">
+                <input type="checkbox" name="gdprConsent" required>
+                <span>Wyrażam zgodę na przetwarzanie moich danych osobowych w celu obsługi zapytania i realizacji kontaktu zwrotnego. *</span>
               </label>
               <p class="cart-details-form__required-note">* - pola wymagane</p>
               <p class="cart-details-form__status" data-cart-form-status aria-live="polite"></p>

--- a/style.css
+++ b/style.css
@@ -3237,6 +3237,20 @@
   resize: vertical;
 }
 
+
+.cart-details-form__checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  color: #f3f5f7;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.cart-details-form__checkbox input[type="checkbox"] {
+  margin-top: 2px;
+}
+
 .cart-details-form__status {
   margin: 0;
   min-height: 1.4em;


### PR DESCRIPTION
### Motivation
- Umożliwić klientowi podanie adresu dostawy lub kodu paczkomatu oraz przesłanie tej informacji do Google Sheets i EmailJS. 
- Zapewnić zgodę na przetwarzanie danych osobowych wymaganą przed wysłaniem zapytania. 
- Zachować obecny wygląd i responsywność formularza przy minimalnych zmianach stylu.

### Description
- Dodano nowe, wymagane pole textarea `Adres dostawy / kod paczkomatu *` z nazwą `delivery_address` i placeholderem `Wpisz adres dostawy albo kod paczkomatu / punktu odbioru` w `sklep/index.html` i `sklep/kalendarz-2026.html`.
- Dodano wymagany checkbox RODO z treścią: `Wyrażam zgodę na przetwarzanie moich danych osobowych w celu obsługi zapytania i realizacji kontaktu zwrotnego. *` i walidacją wyświetlającą komunikat `Musisz zaakceptować zgodę RODO.` jeśli nie jest zaznaczony.
- Zmieniono `shop.js` tak, by payload wysyłany do Google Sheets / Apps Script zawierał `delivery_address`, oraz aby do EmailJS wysyłany był dodatkowy parametr `delivery_address` (przekazywany jako `deliveryAddress` do funkcji i wysyłany w obiekcie emaila, dostępny w szablonie jako `{{delivery_address}}`).
- Dodano niewielkie reguły CSS (`.cart-details-form__checkbox`) w `style.css` dla poprawnego wyrównania checkboxa bez modyfikowania dotychczasowego wyglądu i zachowania responsywności.

### Testing
- Uruchomiono sprawdzenie składni JavaScript poleceniem `node --check shop.js` i zakończyło się sukcesem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1806c4b50083309e290d218036f9fc)