### PR TITLE
Wymagany numer telefonu w formularzu zamówienia

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -452,6 +452,14 @@
           gdprConsentField.dataset.validationBound = 'true';
         }
 
+        const customerPhoneField = form.elements.customerPhone;
+        if (customerPhoneField && !customerPhoneField.dataset.validationBound) {
+          customerPhoneField.addEventListener('input', () => {
+            customerPhoneField.setCustomValidity(customerPhoneField.value.trim() ? '' : 'Uzupełnij wymagane pole: Telefon.');
+          });
+          customerPhoneField.dataset.validationBound = 'true';
+        }
+
         if (!cart.length) {
           if (status) status.textContent = 'Koszyk jest pusty.';
           return;
@@ -460,6 +468,13 @@
         const gdprConsentForSubmit = form.elements.gdprConsent;
         if (gdprConsentForSubmit && 'setCustomValidity' in gdprConsentForSubmit) {
           gdprConsentForSubmit.setCustomValidity(gdprConsentForSubmit.checked ? '' : 'Musisz zaakceptować zgodę RODO.');
+        }
+
+        const customerPhoneForSubmit = form.elements.customerPhone;
+        if (customerPhoneForSubmit && 'setCustomValidity' in customerPhoneForSubmit) {
+          customerPhoneForSubmit.setCustomValidity(
+            customerPhoneForSubmit.value.trim() ? '' : 'Uzupełnij wymagane pole: Telefon.'
+          );
         }
 
         if (!form.reportValidity()) return;

--- a/sklep/czapka-z-daszkiem-exploride.html
+++ b/sklep/czapka-z-daszkiem-exploride.html
@@ -159,8 +159,8 @@
                 <input type="email" name="customerEmail" required autocomplete="email">
               </label>
               <label class="cart-details-form__field">
-                <span>Telefon (opcjonalne)</span>
-                <input type="tel" name="customerPhone" autocomplete="tel">
+                <span>Telefon *</span>
+                <input type="tel" name="customerPhone" required autocomplete="tel">
               </label>
               <label class="cart-details-form__field">
                 <span>Wiadomość (opcjonalne)</span>

--- a/sklep/index.html
+++ b/sklep/index.html
@@ -117,8 +117,8 @@
                 <input type="email" name="customerEmail" required autocomplete="email">
               </label>
               <label class="cart-details-form__field">
-                <span>Telefon (opcjonalne)</span>
-                <input type="tel" name="customerPhone" autocomplete="tel">
+                <span>Telefon *</span>
+                <input type="tel" name="customerPhone" required autocomplete="tel">
               </label>
               <label class="cart-details-form__field">
                 <span>Adres dostawy / kod paczkomatu *</span>

--- a/sklep/kalendarz-2026.html
+++ b/sklep/kalendarz-2026.html
@@ -149,8 +149,8 @@
                 <input type="email" name="customerEmail" required autocomplete="email">
               </label>
               <label class="cart-details-form__field">
-                <span>Telefon (opcjonalne)</span>
-                <input type="tel" name="customerPhone" autocomplete="tel">
+                <span>Telefon *</span>
+                <input type="tel" name="customerPhone" required autocomplete="tel">
               </label>
               <label class="cart-details-form__field">
                 <span>Adres dostawy / kod paczkomatu *</span>

--- a/sklep/t-shirt-damski-classic.html
+++ b/sklep/t-shirt-damski-classic.html
@@ -159,8 +159,8 @@
                 <input type="email" name="customerEmail" required autocomplete="email">
               </label>
               <label class="cart-details-form__field">
-                <span>Telefon (opcjonalne)</span>
-                <input type="tel" name="customerPhone" autocomplete="tel">
+                <span>Telefon *</span>
+                <input type="tel" name="customerPhone" required autocomplete="tel">
               </label>
               <label class="cart-details-form__field">
                 <span>Wiadomość (opcjonalne)</span>

--- a/sklep/t-shirt-meski-classic.html
+++ b/sklep/t-shirt-meski-classic.html
@@ -159,8 +159,8 @@
                 <input type="email" name="customerEmail" required autocomplete="email">
               </label>
               <label class="cart-details-form__field">
-                <span>Telefon (opcjonalne)</span>
-                <input type="tel" name="customerPhone" autocomplete="tel">
+                <span>Telefon *</span>
+                <input type="tel" name="customerPhone" required autocomplete="tel">
               </label>
               <label class="cart-details-form__field">
                 <span>Wiadomość (opcjonalne)</span>


### PR DESCRIPTION
### Motivation
- Formularz zamówienia powinien wymagać numeru telefonu, aby zapytanie zawierało kontakt zwrotny i użytkownik otrzymał jasny komunikat o brakujących polach.

### Description
- Zmieniono etykietę pola telefonu z "Telefon (opcjonalne)" na "Telefon *" w plikach formularzy sklepu (`sklep/index.html`, `sklep/kalendarz-2026.html`, `sklep/t-shirt-meski-classic.html`, `sklep/t-shirt-damski-classic.html`, `sklep/czapka-z-daszkiem-exploride.html`).
- Dodano atrybut `required` do pola `customerPhone` we wszystkich zmienionych formularzach, aby wymusić walidację HTML.
- W `shop.js` dodano walidację JavaScript: nasłuchiwanie `input` na `customerPhone` ustawiające `setCustomValidity` oraz sprawdzenie przed wysyłką z komunikatem `Uzupełnij wymagane pole: Telefon.`, aby formularz nie został wysłany bez numeru telefonu.

### Testing
- Sprawdzono obecność zmian wyszukując etykiety, atrybut `required` i komunikat walidacji za pomocą `rg -n "Telefon \\*|customerPhone\" required|Uzupełnij wymagane pole: Telefon" sklep/*.html shop.js` i testy przeszły.
- Potwierdzono zmiany w drzewie roboczym i utworzono commit opisujący wprowadzone modyfikacje za pomocą `git status --short` i `git commit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1809b81c608330bb0c09309abdef33)