### PR TITLE
Move product back link above hero text on product pages

### DIFF
--- a/sklep/czapka-z-daszkiem-exploride.html
+++ b/sklep/czapka-z-daszkiem-exploride.html
@@ -52,6 +52,7 @@
       </div>
       <button class="button button--primary" type="button" data-open-cart>Otwórz koszyk</button>
     </div>
+    <a class="product-back-link" href="./index.html">←</a>
     <div class="shop-hero__text">
       <p class="eyebrow">ExploRide</p>
       <h1 data-product-title>Czapka z daszkiem ExploRide</h1>
@@ -60,7 +61,6 @@
   </div>
 
   <main class="product-main">
-    <a class="product-back-link" href="./index.html">←</a>
     <section class="product-grid">
       <figure class="product-media">
         <div class="product-photo-wrapper">

--- a/sklep/kalendarz-2026.html
+++ b/sklep/kalendarz-2026.html
@@ -52,6 +52,7 @@
       </div>
       <button class="button button--primary" type="button" data-open-cart>Otwórz koszyk</button>
     </div>
+    <a class="product-back-link" href="./index.html">←</a>
     <div class="shop-hero__text">
       <p class="eyebrow">ExploRide</p>
       <h1 data-product-title>Kalendarz ExploRide Urbex 2026</h1>
@@ -60,7 +61,6 @@
   </div>
 
   <main class="product-main">
-    <a class="product-back-link" href="./index.html">←</a>
     <section class="product-grid">
       <figure class="product-media">
         <div class="product-photo-wrapper">

--- a/sklep/t-shirt-damski-classic.html
+++ b/sklep/t-shirt-damski-classic.html
@@ -52,6 +52,7 @@
       </div>
       <button class="button button--primary" type="button" data-open-cart>Otwórz koszyk</button>
     </div>
+    <a class="product-back-link" href="./index.html">←</a>
     <div class="shop-hero__text">
       <p class="eyebrow">ExploRide</p>
       <h1 data-product-title>T-shirt klasyczny ExploRide damski</h1>
@@ -60,7 +61,6 @@
   </div>
 
   <main class="product-main">
-    <a class="product-back-link" href="./index.html">←</a>
     <section class="product-grid">
       <figure class="product-media">
         <div class="product-photo-wrapper">

--- a/sklep/t-shirt-meski-classic.html
+++ b/sklep/t-shirt-meski-classic.html
@@ -52,6 +52,7 @@
       </div>
       <button class="button button--primary" type="button" data-open-cart>Otwórz koszyk</button>
     </div>
+    <a class="product-back-link" href="./index.html">←</a>
     <div class="shop-hero__text">
       <p class="eyebrow">ExploRide</p>
       <h1 data-product-title>T-shirt klasyczny ExploRide męski</h1>
@@ -60,7 +61,6 @@
   </div>
 
   <main class="product-main">
-    <a class="product-back-link" href="./index.html">←</a>
     <section class="product-grid">
       <figure class="product-media">
         <div class="product-photo-wrapper">


### PR DESCRIPTION
### Motivation
- Improve product page layout by placing the back link next to the hero area so it is visually closer to the product title and context.
- Ensure consistent DOM structure across all product detail pages for predictable styling and behavior.

### Description
- Moved the `<a class="product-back-link" href="./index.html">←</a>` element from inside the `main.product-main` block to directly above the `.shop-hero__text` within the `.shop-hero.shop-hero--compact` area.
- Removed the previous duplicate placement of the back link from the `main` section.
- Applied the same change to the following pages: `sklep/t-shirt-meski-classic.html`, `sklep/t-shirt-damski-classic.html`, `sklep/kalendarz-2026.html`, and `sklep/czapka-z-daszkiem-exploride.html`.
- This is a DOM-only change (no CSS or JS was modified).

### Testing
- Located occurrences of `product-back-link` and `shop-hero__text` across product pages using a code search and confirmed the expected anchors were present before modification.
- Executed an automated script to update the four product files and verified the script completed successfully.
- Inspected the resulting file diffs to confirm the anchor now appears above `.shop-hero__text` and is no longer duplicated inside `main.product-main`.
- All automated checks and file inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a181f6de0dc8330a4db2bdb08602155)