### PR TITLE
Mobilna nawigacja pod tytułem: zastąpienie sociali linkami menu

### DIFF
--- a/main.js
+++ b/main.js
@@ -184,8 +184,74 @@
     }
   }
 
+
+  function initMobileTitleNav() {
+    const header = document.querySelector('header');
+    const titleSocials = document.querySelector('.site-title-socials');
+    if (!header || !titleSocials) {
+      return;
+    }
+
+    const sourceNav = header.querySelector('.top-nav');
+    if (!sourceNav) {
+      return;
+    }
+
+    const existing = titleSocials.querySelector('.mobile-title-nav');
+    if (existing) {
+      return;
+    }
+
+    const navLinks = Array.from(sourceNav.querySelectorAll('.nav-link[href]:not(.nav-link--downloads)'));
+    if (!navLinks.length) {
+      return;
+    }
+
+    const primaryCount = 4;
+    const primaryLinks = navLinks.slice(0, primaryCount);
+    const overflowLinks = navLinks.slice(primaryCount);
+
+    const mobileNav = document.createElement('div');
+    mobileNav.className = 'mobile-title-nav';
+    mobileNav.setAttribute('aria-label', 'Skróty nawigacji strony');
+
+    primaryLinks.forEach((link) => {
+      const clone = link.cloneNode(true);
+      clone.classList.remove('nav-link', 'nav-link--home', 'nav-link--about', 'nav-link--gallery', 'nav-link--links', 'nav-link--support', 'nav-link--contact', 'nav-link--downloads');
+      clone.classList.add('mobile-title-nav__link');
+      clone.removeAttribute('role');
+      clone.removeAttribute('style');
+      mobileNav.appendChild(clone);
+    });
+
+    if (overflowLinks.length) {
+      const details = document.createElement('details');
+      details.className = 'mobile-title-nav__more';
+
+      const summary = document.createElement('summary');
+      summary.className = 'mobile-title-nav__more-trigger';
+      summary.textContent = 'Więcej';
+      details.appendChild(summary);
+
+      const menu = document.createElement('div');
+      menu.className = 'mobile-title-nav__more-menu';
+
+      overflowLinks.forEach((link) => {
+        const clone = link.cloneNode(true);
+        clone.classList.remove('nav-link', 'nav-link--home', 'nav-link--about', 'nav-link--gallery', 'nav-link--links', 'nav-link--support', 'nav-link--contact', 'nav-link--downloads');
+        clone.classList.add('mobile-title-nav__more-link');
+        menu.appendChild(clone);
+      });
+
+      details.appendChild(menu);
+      mobileNav.appendChild(details);
+    }
+
+    titleSocials.appendChild(mobileNav);
+  }
   function init() {
     initNavToggle();
+    initMobileTitleNav();
 
     if (typeof history !== 'undefined' && 'scrollRestoration' in history) {
       history.scrollRestoration = 'manual';

--- a/style.css
+++ b/style.css
@@ -481,6 +481,100 @@
     body.has-open-nav {
       overflow: hidden;
     }
+
+    .mobile-title-nav {
+      display: none;
+    }
+
+    @media (max-width: 767px) {
+      .site-title-socials {
+        justify-content: center;
+        padding: 6px 12px 0;
+        overflow: visible;
+      }
+
+      .site-title-socials__button {
+        display: none;
+      }
+
+      .mobile-title-nav {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        width: 100%;
+        flex-wrap: nowrap;
+      }
+
+      .mobile-title-nav__link,
+      .mobile-title-nav__more-trigger {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 40px;
+        padding: 8px 10px;
+        border-radius: 999px;
+        border: 1px solid rgba(18, 18, 18, 0.2);
+        background: linear-gradient(135deg, #eef2f6 0%, #9aa3ad 100%);
+        color: #222;
+        font-family: 'BebasNeue', 'Base02', Arial, Helvetica, sans-serif;
+        font-size: clamp(0.9rem, 3.4vw, 1rem);
+        letter-spacing: 0.04em;
+        line-height: 1;
+        text-transform: uppercase;
+        text-decoration: none;
+        white-space: nowrap;
+        cursor: pointer;
+      }
+
+      .mobile-title-nav__link {
+        flex: 1 1 0;
+        min-width: 0;
+      }
+
+      .mobile-title-nav__more {
+        position: relative;
+      }
+
+      .mobile-title-nav__more > summary {
+        list-style: none;
+      }
+
+      .mobile-title-nav__more > summary::-webkit-details-marker {
+        display: none;
+      }
+
+      .mobile-title-nav__more-menu {
+        position: absolute;
+        top: calc(100% + 6px);
+        right: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        min-width: 160px;
+        padding: 8px;
+        border-radius: 14px;
+        border: 1px solid rgba(255, 255, 255, 0.16);
+        background: rgba(12, 12, 12, 0.95);
+        box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
+        z-index: 8;
+      }
+
+      .mobile-title-nav__more-link {
+        display: inline-flex;
+        justify-content: center;
+        align-items: center;
+        min-height: 40px;
+        padding: 8px 10px;
+        border-radius: 999px;
+        border: 1px solid rgba(255, 255, 255, 0.22);
+        color: #f4f4f4;
+        text-decoration: none;
+        font-family: 'BebasNeue', 'Base02', Arial, Helvetica, sans-serif;
+        letter-spacing: 0.05em;
+      }
+    }
     @media (max-width: 767px) {
       :root {
         --sidebar-width: min(240px, 60vw);


### PR DESCRIPTION
### Motivation
- Na wersji mobilnej usunąć przyciski social pod napisem `EXPLORIDE.PL` i w ich miejscu pokazać najważniejsze linki serwisu, korzystając z istniejącego menu, żeby uniknąć duplikacji treści.
- Zapewnić czytelne, wystarczająco duże elementy dotykowe (min. 40px wysokości) i zachować resztę linków w wygodnym do rozwinięcia miejscu.
- Zmiany mają dotyczyć wyłącznie widoków mobilnych, bez wpływu na wersję desktopową.

### Description
- Dodano funkcję `initMobileTitleNav()` w `main.js`, która klonuje linki z istniejącego `header .top-nav`, tworzy kontener `.mobile-title-nav`, wstawia pierwsze 4 linki w jednym rzędzie i umieszcza pozostałe w rozwijanym `details` jako „Więcej”.
- Zarejestrowano wywołanie `initMobileTitleNav()` w `init()` tak, by na starcie inicjować mobilną nawigację razem z obsługą toggle menu.
- Zaktualizowano `style.css` o ukrycie przycisków social na mobile (`.site-title-socials__button { display: none; }`) oraz stylizację `.mobile-title-nav`, `.mobile-title-nav__link`, `.mobile-title-nav__more` i `.mobile-title-nav__more-menu` wewnątrz `@media (max-width: 767px)` (m.in. `min-height: 40px`, paddingy, wygląd rozwijanego menu).
- Zmiany dotyczą tylko dwóch plików: `main.js` i `style.css` i są ograniczone warunkami media query do mobilnych rozdzielczości.

### Testing
- Przeprowadzono inspekcję zmian i wygenerowano diff przez `git diff -- main.js style.css`, które pokazało dodanie funkcji JS i sekcji CSS bez konfliktów (sukces).
- Sprawdzono status repo przez `git status --short` oraz wykonano commit z opisem, które zakończyły się pomyślnie (sukces).
- Przeszukano pliki źródłowe poleceniem `rg` aby zweryfikować obecność selektorów i punktów wstawienia (sukces).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18397e6ab48330816cc1b67e5696bf)