### PR TITLE
Increase shop-item image to 150% and widen grid column

### DIFF
--- a/style.css
+++ b/style.css
@@ -2810,7 +2810,7 @@
 
 .shop-item {
   display: grid;
-  grid-template-columns: 124px 1fr;
+  grid-template-columns: 186px 1fr;
   align-items: start;
   gap: 16px;
   background: rgba(0, 0, 0, 0.7);
@@ -2851,13 +2851,14 @@
 
 .shop-item__image-link:hover .shop-item__image img,
 .shop-item__image-link:focus-visible .shop-item__image img {
-  transform: scale(1.045);
+  transform: scale(1.57);
 }
 
 .shop-item__image img {
   width: 100%;
   height: 100%;
   object-fit: contain;
+  transform: scale(1.5);
   border-radius: inherit;
   display: block;
   transition: transform 0.28s ease;


### PR DESCRIPTION
### Motivation
- Make product thumbnails visually larger (150%) while preventing the adjacent text from overlapping the image by allocating more grid space to the image column.

### Description
- Update `style.css` to change `.shop-item` grid first column from `124px` to `186px` so the text content shifts right and avoids overlapping the enlarged image.
- Add `transform: scale(1.5)` to `.shop-item__image img` to set the base image size to 150% and keep `overflow: hidden` on the image container to crop overflow.
- Increase the hover/focus zoom from `scale(1.045)` to `scale(1.57)` so the hover effect still slightly enlarges the image relative to the new base scale.

### Testing
- Ran `git diff --check` which reported no issues and succeeded. 
- Verified repository status with `git status --short` and committed the change with message `Adjust shop item image sizing` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18ea5596b08330a2718e792b8b35d1)