### PR TITLE
Zmniejsz przyciski linków na stronie głównej

### DIFF
--- a/style.css
+++ b/style.css
@@ -1912,6 +1912,26 @@
       display: grid;
       grid-template-columns: repeat(2, minmax(0, 1fr));
       justify-items: center;
+      gap: clamp(12px, 2.6vw, 18px);
+    }
+    .home-links__buttons .links-button {
+      flex: initial;
+      min-width: min(100%, 210px);
+      max-width: 280px;
+      gap: clamp(10px, 2vw, 14px);
+      padding: clamp(12px, 2.2vw, 16px) clamp(16px, 3vw, 22px);
+      border-radius: clamp(14px, 3vw, 20px);
+      box-shadow: 0 10px 22px rgba(0, 0, 0, 0.24);
+    }
+    .home-links__buttons .links-button__icon {
+      width: 1.18em;
+      height: 1.18em;
+    }
+    .home-links__buttons .links-button__title {
+      font-size: clamp(0.98rem, 2.1vw, 1.14rem);
+    }
+    .home-links__buttons .links-button__handle {
+      font-size: clamp(0.74rem, 1.8vw, 0.86rem);
     }
     @media (max-width: 720px) {
       .home-links__buttons {


### PR DESCRIPTION
### Motivation
- Przyciski w sekcji „Linki” na stronie głównej miały zbyt duże tło i odstępy, więc trzeba je zmniejszyć, zachowując wygląd na dedykowanej stronie `linki.html`.

### Description
- Dodano lokalne nadpisania CSS w `style.css` pod selektorem `.home-links__buttons` aby zmniejszyć odstęp między przyciskami (`gap`).
- Dla przycisków w tej sekcji wprowadzono mniejsze wymiary i proporcje: `flex`, `min-width`, `max-width`, `gap`, `padding`, `border-radius` i `box-shadow`.
- Zmniejszono rozmiar ikony oraz font-size tytułu i uchwytu w `.home-links__buttons` tak, by zachować proporcje przy mniejszym tle.
- Zmiany są ograniczone do sekcji strony głównej (`.home-links__buttons`) i nie modyfikują globalnych styli używanych na stronie `linki.html`.

### Testing
- Uruchomiono `git diff --check` i nie zgłoszono błędów (sukces). 
- Lokalny serwer uruchomiony poleceniem `python3 -m http.server` i sprawdzono dostępność strony przez `curl -I http://127.0.0.1:8765/`, które zwróciło `200 OK` (sukces).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1942480e4c8330834f35576efcb478)