### PR TITLE
Dodaj kopiowanie numeru konta do schowka z 5s komunikatem

### DIFF
--- a/index.html
+++ b/index.html
@@ -854,8 +854,13 @@ document.addEventListener('DOMContentLoaded', () => {
             <span>PayPal</span>
           </a>
         </li>
-        <li>
-          <div class="home-support__link home-support__link--static">
+        <li class="home-support__copy-item">
+          <button
+            class="home-support__link home-support__link--static"
+            type="button"
+            data-copy-account="76 1050 1894 1000 0097 2209 8382"
+            aria-describedby="home-support-copy-feedback"
+          >
             <span class="brand-icon brand-icon--sm brand-icon--bank" aria-hidden="true">
               <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
                 <path d="M4 9.3 12 4l8 5.3v1.4H4z" fill="currentColor"></path>
@@ -867,7 +872,8 @@ document.addEventListener('DOMContentLoaded', () => {
               </svg>
             </span>
             <span>Przelew <span class="home-support__account">76 1050 1894 1000 0097 2209 8382</span></span>
-          </div>
+          </button>
+          <span class="home-support__copy-feedback" id="home-support-copy-feedback" role="status" aria-live="polite"></span>
         </li>
       </ul>
     </div>

--- a/main.js
+++ b/main.js
@@ -271,10 +271,73 @@
 
     titleSocials.appendChild(mobileNav);
   }
+
+
+  function copyTextToClipboard(text) {
+    if (navigator.clipboard && window.isSecureContext) {
+      return navigator.clipboard.writeText(text);
+    }
+
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '-9999px';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+
+    try {
+      const copied = document.execCommand('copy');
+      return copied ? Promise.resolve() : Promise.reject(new Error('Copy command failed'));
+    } finally {
+      textarea.remove();
+    }
+  }
+
+
+  function initHomeSupportAccountCopy() {
+    const copyButton = document.querySelector('[data-copy-account]');
+    if (!copyButton) {
+      return;
+    }
+
+    const accountNumber = copyButton.getAttribute('data-copy-account');
+    const feedback = document.getElementById('home-support-copy-feedback');
+    if (!accountNumber || !feedback) {
+      return;
+    }
+
+    let feedbackTimer = null;
+
+    const showFeedback = (message) => {
+      feedback.textContent = message;
+      feedback.classList.add('is-visible');
+
+      if (feedbackTimer) {
+        window.clearTimeout(feedbackTimer);
+      }
+
+      feedbackTimer = window.setTimeout(() => {
+        feedback.classList.remove('is-visible');
+      }, 5000);
+    };
+
+    copyButton.addEventListener('click', async () => {
+      try {
+        await copyTextToClipboard(accountNumber);
+        showFeedback('Skopiowano numer konta');
+      } catch (error) {
+        showFeedback('Nie udało się skopiować numeru');
+      }
+    });
+  }
+
   function init() {
     initMobileHeaderTitle();
     initNavToggle();
     initMobileTitleNav();
+    initHomeSupportAccountCopy();
 
     if (typeof history !== 'undefined' && 'scrollRestoration' in history) {
       history.scrollRestoration = 'manual';

--- a/style.css
+++ b/style.css
@@ -1993,6 +1993,7 @@
       border: 1px solid rgba(255, 255, 255, 0.08);
       border-radius: 999px;
       color: #fff;
+      font: inherit;
       text-decoration: none;
       transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
     }
@@ -2004,7 +2005,36 @@
       outline: none;
     }
     .home-support__link--static {
-      cursor: default;
+      cursor: copy;
+    }
+    .home-support__copy-item {
+      position: relative;
+      display: inline-flex;
+      justify-content: center;
+    }
+    .home-support__copy-feedback {
+      position: absolute;
+      top: calc(100% + 6px);
+      left: 50%;
+      z-index: 2;
+      width: max-content;
+      max-width: min(260px, 90vw);
+      padding: 4px 10px;
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      border-radius: 999px;
+      background: rgba(12, 12, 14, 0.94);
+      box-shadow: 0 8px 18px rgba(0, 0, 0, 0.28);
+      color: rgba(255, 255, 255, 0.92);
+      font-size: 0.78rem;
+      line-height: 1.35;
+      opacity: 0;
+      pointer-events: none;
+      transform: translate(-50%, -4px);
+      transition: opacity 0.16s ease, transform 0.16s ease;
+    }
+    .home-support__copy-feedback.is-visible {
+      opacity: 1;
+      transform: translate(-50%, 0);
     }
     .home-support__account {
       font-weight: 600;


### PR DESCRIPTION
### Motivation
- Ułatwić użytkownikom skopiowanie numeru konta z sekcji wsparcia bez konieczności ręcznego zaznaczania tekstu.
- Dodać prosty, dostępny feedback informujący że numer został skopiowany. 

### Description
- Zmieniono statyczny element z numerem konta na przycisk z atrybutem `data-copy-account` i identyfikatorem feedbacku `home-support-copy-feedback` w `index.html`.
- Dodano funkcję `copyTextToClipboard` z fallbackem (tworzenie ukrytego `textarea`) oraz inicjalizator `initHomeSupportAccountCopy` w `main.js`, które nasłuchują kliknięcia i kopiują numer do schowka.
- Dodano komunikat statusu z `role=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19435c012c833092fbd8d0389885ac)