### PR TITLE
Make support account copyable and align mobile support buttons

### DIFF
--- a/main.js
+++ b/main.js
@@ -296,40 +296,43 @@
   }
 
 
-  function initHomeSupportAccountCopy() {
-    const copyButton = document.querySelector('[data-copy-account]');
-    if (!copyButton) {
+  function initSupportAccountCopy() {
+    const copyButtons = document.querySelectorAll('[data-copy-account]');
+    if (!copyButtons.length) {
       return;
     }
 
-    const accountNumber = copyButton.getAttribute('data-copy-account');
-    const feedback = document.getElementById('home-support-copy-feedback');
-    if (!accountNumber || !feedback) {
-      return;
-    }
-
-    let feedbackTimer = null;
-
-    const showFeedback = (message) => {
-      feedback.textContent = message;
-      feedback.classList.add('is-visible');
-
-      if (feedbackTimer) {
-        window.clearTimeout(feedbackTimer);
+    copyButtons.forEach((copyButton) => {
+      const accountNumber = copyButton.getAttribute('data-copy-account');
+      const feedbackId = copyButton.getAttribute('aria-describedby');
+      const feedback = feedbackId ? document.getElementById(feedbackId) : null;
+      if (!accountNumber || !feedback) {
+        return;
       }
 
-      feedbackTimer = window.setTimeout(() => {
-        feedback.classList.remove('is-visible');
-      }, 5000);
-    };
+      let feedbackTimer = null;
 
-    copyButton.addEventListener('click', async () => {
-      try {
-        await copyTextToClipboard(accountNumber);
-        showFeedback('Skopiowano numer konta');
-      } catch (error) {
-        showFeedback('Nie udało się skopiować numeru');
-      }
+      const showFeedback = (message) => {
+        feedback.textContent = message;
+        feedback.classList.add('is-visible');
+
+        if (feedbackTimer) {
+          window.clearTimeout(feedbackTimer);
+        }
+
+        feedbackTimer = window.setTimeout(() => {
+          feedback.classList.remove('is-visible');
+        }, 5000);
+      };
+
+      copyButton.addEventListener('click', async () => {
+        try {
+          await copyTextToClipboard(accountNumber);
+          showFeedback('Skopiowano numer konta');
+        } catch (error) {
+          showFeedback('Nie udało się skopiować numeru');
+        }
+      });
     });
   }
 
@@ -337,7 +340,7 @@
     initMobileHeaderTitle();
     initNavToggle();
     initMobileTitleNav();
-    initHomeSupportAccountCopy();
+    initSupportAccountCopy();
 
     if (typeof history !== 'undefined' && 'scrollRestoration' in history) {
       history.scrollRestoration = 'manual';

--- a/style.css
+++ b/style.css
@@ -2048,7 +2048,9 @@
       }
       .home-support__link,
       .home-support__link--static {
+        box-sizing: border-box;
         justify-content: flex-start;
+        width: 100%;
       }
     }
 
@@ -2142,13 +2144,20 @@
       background: rgba(255, 255, 255, 0.05);
       border: 1px solid rgba(255, 255, 255, 0.1);
       border-radius: 16px;
+      box-sizing: border-box;
       color: #fff;
+      appearance: none;
+      font: inherit;
+      text-align: left;
       text-decoration: none;
       transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
       height: 100%;
+      width: 100%;
     }
     a.support-option:hover,
-    a.support-option:focus-visible {
+    button.support-option:hover,
+    a.support-option:focus-visible,
+    button.support-option:focus-visible {
       transform: translateY(-2px);
       border-color: #e50914;
       box-shadow: 0 12px 24px rgba(229, 9, 20, 0.22);
@@ -2177,7 +2186,34 @@
       word-break: break-word;
     }
     .support-option--static {
-      cursor: default;
+      cursor: copy;
+    }
+    .support-copy-item {
+      position: relative;
+    }
+    .support-copy-feedback {
+      position: absolute;
+      top: calc(100% + 6px);
+      left: 50%;
+      z-index: 2;
+      width: max-content;
+      max-width: min(280px, 90vw);
+      padding: 4px 10px;
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      border-radius: 999px;
+      background: rgba(12, 12, 14, 0.94);
+      box-shadow: 0 8px 18px rgba(0, 0, 0, 0.28);
+      color: rgba(255, 255, 255, 0.92);
+      font-size: 0.78rem;
+      line-height: 1.35;
+      opacity: 0;
+      pointer-events: none;
+      transform: translate(-50%, -4px);
+      transition: opacity 0.16s ease, transform 0.16s ease;
+    }
+    .support-copy-feedback.is-visible {
+      opacity: 1;
+      transform: translate(-50%, 0);
     }
     .support-thanks {
       margin: 8px 0 0;

--- a/wesprzyj-nas.html
+++ b/wesprzyj-nas.html
@@ -111,8 +111,13 @@
               </span>
             </a>
           </li>
-          <li>
-            <div class="support-option support-option--static">
+          <li class="support-copy-item">
+            <button
+              class="support-option support-option--static"
+              type="button"
+              data-copy-account="76 1050 1894 1000 0097 2209 8382"
+              aria-describedby="support-copy-feedback"
+            >
               <span class="brand-icon brand-icon--lg brand-icon--bank" aria-hidden="true">
                 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
                   <path d="M4 9.3 12 4l8 5.3v1.4H4z" fill="currentColor"></path>
@@ -127,7 +132,8 @@
                 <span class="support-option-name">Przelew bankowy</span>
                 <span class="support-option-note">76 1050 1894 1000 0097 2209 8382</span>
               </span>
-            </div>
+            </button>
+            <span class="support-copy-feedback" id="support-copy-feedback" role="status" aria-live="polite"></span>
           </li>
         </ul>
       </section>


### PR DESCRIPTION
### Motivation
- Let users copy the bank transfer account number by clicking the bank card on the support page and enable the same behavior from the homepage.
- On mobile, make homepage support buttons’ background span the same width as the account button so visuals align while preserving desktop sizes.

### Description
- Converted the static bank transfer block into a `button` with `data-copy-account` and `aria-describedby` and added a feedback element in `wesprzyj-nas.html`.
- Replaced `initHomeSupportAccountCopy` with `initSupportAccountCopy` in `main.js` to attach copy-to-clipboard handling to all elements with `data-copy-account`, including clipboard fallback and per-button feedback timers.
- Updated `style.css` to make `.home-support__link`/`--static` full-width on small screens, add button reset/appearance and width rules, and introduce `.support-copy-feedback` styles and cursor behavior for copyable options.
- Preserved desktop sizing and existing hover/focus interactions while adding support for `button.support-option` alongside `a.support-option`.

### Testing
- Ran `node --check main.js` which passed.
- Parsed `index.html` and `wesprzyj-nas.html` with Python `HTMLParser` which succeeded.
- Ran `git diff --check` and verified HTTP HEAD responses with `curl -I` for `/` and `/wesprzyj-nas.html` which returned 200.
- Attempted Playwright screenshot but `npx playwright install chromium` failed because the browser download returned `403 Domain forbidden`, so visual screenshot step was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19458f96d4833089330797a622cf5b)