### PR TITLE
Center homepage support button content

### DIFF
--- a/style.css
+++ b/style.css
@@ -1987,7 +1987,9 @@
     .home-support__link--static {
       display: inline-flex;
       align-items: center;
+      justify-content: center;
       gap: 10px;
+      text-align: center;
       padding: 8px 16px;
       background: rgba(255, 255, 255, 0.05);
       border: 1px solid rgba(255, 255, 255, 0.08);
@@ -2049,7 +2051,7 @@
       .home-support__link,
       .home-support__link--static {
         box-sizing: border-box;
-        justify-content: flex-start;
+        justify-content: center;
         width: 100%;
       }
     }


### PR DESCRIPTION
### Motivation
- Ensure the inline contents (icons and labels) of the homepage support buttons are visually centered on desktop and on mobile full-width buttons.

### Description
- Updated `style.css` to add `justify-content: center` and `text-align: center` to the `.home-support__link, .home-support__link--static` rule and changed the mobile `@media (max-width: 520px)` variant to use `justify-content: center` instead of `flex-start` (file changed: `style.css`).

### Testing
- Ran a `python3` assertion script that checks the CSS rules are present and mobile variant is centered, which succeeded.
- Ran `git diff --check` to verify no style issues, which succeeded.
- Captured a full-page screenshot with `npx playwright` to verify visual result, which completed successfully (Playwright browser dependencies were installed during the run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19497404e48330a91c1147ca653304)