### PR TITLE
Update navigation to extensionless URLs and keep socials on homepage only

### DIFF
--- a/filmy.html
+++ b/filmy.html
@@ -10,7 +10,7 @@
 </head>
 <body class="page-videos">
   <header data-nav-layout="sidebar">
-    <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
+    <a class="brand" href="/" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
@@ -22,15 +22,15 @@
       <span class="nav-toggle__label">Menu</span>
     </button>
     <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
-      <a class="nav-link nav-link--home" href="index.html">Strona główna</a>
-      <a class="nav-link nav-link--about" href="onas.html">O nas</a>
-      <a class="nav-link nav-link--gallery" href="galeria.html">Galeria</a>
-      <a class="nav-link nav-link--links" href="linki.html">Linki</a>
+      <a class="nav-link nav-link--home" href="/">Strona główna</a>
+      <a class="nav-link nav-link--about" href="/onas">O nas</a>
+      <a class="nav-link nav-link--gallery" href="/galeria">Galeria</a>
+      <a class="nav-link nav-link--links" href="/linki">Linki</a>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
-      <a class="nav-link" href="sklep/">Sklep</a>
-      <a class="nav-link nav-link--support" href="wesprzyj-nas.html">Wesprzyj nas</a>
-      <a class="nav-link nav-link--contact" href="kontakt.html">Kontakt</a>
-      <a class="nav-link nav-link--downloads" href="materialy.html">Materiały do pobrania</a>
+      <a class="nav-link" href="/sklep">Sklep</a>
+      <a class="nav-link nav-link--support" href="/wesprzyj-nas">Wesprzyj nas</a>
+      <a class="nav-link nav-link--contact" href="/kontakt">Kontakt</a>
+      <a class="nav-link nav-link--downloads" href="/materialy">Materiały do pobrania</a>
       <div class="nav-divider" role="presentation"></div>
       <div class="nav-links-section" aria-label="Linki społecznościowe">
         <span class="nav-links-section__title">Linki</span>
@@ -43,13 +43,6 @@
   </header>
 
   <h1 class="site-title">ExploRide.pl</h1>
-
-  <div class="site-title-socials" aria-label="Skróty do social mediów ExploRide">
-    <a class="site-title-socials__button links-button--yt" href="https://www.youtube.com/@ExploRideURBEX" target="_blank" rel="noopener noreferrer">YouTube</a>
-    <a class="site-title-socials__button links-button--fb" href="https://www.facebook.com/ExploRideURBEX" target="_blank" rel="noopener noreferrer">Facebook</a>
-    <a class="site-title-socials__button links-button--ig" href="https://www.instagram.com/exploride.urbex" target="_blank" rel="noopener noreferrer">Instagram</a>
-    <a class="site-title-socials__button links-button--tt" href="https://www.tiktok.com/@exploride.urbex" target="_blank" rel="noopener noreferrer">TikTok</a>
-  </div>
 
     <hr class="divider" />
 

--- a/galeria.html
+++ b/galeria.html
@@ -10,7 +10,7 @@
 </head>
 <body class="page-gallery">
   <header data-nav-layout="sidebar">
-    <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
+    <a class="brand" href="/" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
@@ -22,15 +22,15 @@
       <span class="nav-toggle__label">Menu</span>
     </button>
     <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
-      <a class="nav-link nav-link--home" href="index.html">Strona główna</a>
-      <a class="nav-link nav-link--about" href="onas.html">O nas</a>
-      <a class="nav-link nav-link--gallery" href="galeria.html" aria-current="page">Galeria</a>
-      <a class="nav-link nav-link--links" href="linki.html">Linki</a>
+      <a class="nav-link nav-link--home" href="/">Strona główna</a>
+      <a class="nav-link nav-link--about" href="/onas">O nas</a>
+      <a class="nav-link nav-link--gallery" href="/galeria" aria-current="page">Galeria</a>
+      <a class="nav-link nav-link--links" href="/linki">Linki</a>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
-      <a class="nav-link" href="sklep/">Sklep</a>
-      <a class="nav-link nav-link--support" href="wesprzyj-nas.html">Wesprzyj nas</a>
-      <a class="nav-link nav-link--contact" href="kontakt.html">Kontakt</a>
-      <a class="nav-link nav-link--downloads" href="materialy.html">Materiały do pobrania</a>
+      <a class="nav-link" href="/sklep">Sklep</a>
+      <a class="nav-link nav-link--support" href="/wesprzyj-nas">Wesprzyj nas</a>
+      <a class="nav-link nav-link--contact" href="/kontakt">Kontakt</a>
+      <a class="nav-link nav-link--downloads" href="/materialy">Materiały do pobrania</a>
       <div class="nav-divider" role="presentation"></div>
       <div class="nav-links-section" aria-label="Linki społecznościowe">
         <span class="nav-links-section__title">Linki</span>
@@ -43,13 +43,6 @@
   </header>
 
   <h1 class="site-title">ExploRide.pl</h1>
-
-  <div class="site-title-socials" aria-label="Skróty do social mediów ExploRide">
-    <a class="site-title-socials__button links-button--yt" href="https://www.youtube.com/@ExploRideURBEX" target="_blank" rel="noopener noreferrer">YouTube</a>
-    <a class="site-title-socials__button links-button--fb" href="https://www.facebook.com/ExploRideURBEX" target="_blank" rel="noopener noreferrer">Facebook</a>
-    <a class="site-title-socials__button links-button--ig" href="https://www.instagram.com/exploride.urbex" target="_blank" rel="noopener noreferrer">Instagram</a>
-    <a class="site-title-socials__button links-button--tt" href="https://www.tiktok.com/@exploride.urbex" target="_blank" rel="noopener noreferrer">TikTok</a>
-  </div>
 
     <hr class="divider" />
 

--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@
   </head>
 <body class="page-home">
   <header data-nav-layout="sidebar">
-    <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
+    <a class="brand" href="/" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
@@ -200,15 +200,15 @@
       <span class="nav-toggle__label">Menu</span>
     </button>
     <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
-      <a class="nav-link nav-link--home" href="index.html" aria-current="page">Strona główna</a>
-      <a class="nav-link nav-link--about" href="onas.html">O nas</a>
-      <a class="nav-link nav-link--gallery" href="galeria.html">Galeria</a>
-      <a class="nav-link nav-link--links" href="linki.html">Linki</a>
+      <a class="nav-link nav-link--home" href="/" aria-current="page">Strona główna</a>
+      <a class="nav-link nav-link--about" href="/onas">O nas</a>
+      <a class="nav-link nav-link--gallery" href="/galeria">Galeria</a>
+      <a class="nav-link nav-link--links" href="/linki">Linki</a>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
-      <a class="nav-link" href="sklep/">Sklep</a>
-      <a class="nav-link nav-link--support" href="wesprzyj-nas.html">Wesprzyj nas</a>
-      <a class="nav-link nav-link--contact" href="kontakt.html">Kontakt</a>
-      <a class="nav-link nav-link--downloads" href="materialy.html">Materiały do pobrania</a>
+      <a class="nav-link" href="/sklep">Sklep</a>
+      <a class="nav-link nav-link--support" href="/wesprzyj-nas">Wesprzyj nas</a>
+      <a class="nav-link nav-link--contact" href="/kontakt">Kontakt</a>
+      <a class="nav-link nav-link--downloads" href="/materialy">Materiały do pobrania</a>
       <div class="nav-divider" role="presentation"></div>
       <div class="nav-links-section" aria-label="Linki społecznościowe">
         <span class="nav-links-section__title">Linki</span>

--- a/kontakt.html
+++ b/kontakt.html
@@ -10,7 +10,7 @@
 </head>
 <body class="page-contact">
   <header data-nav-layout="sidebar">
-    <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
+    <a class="brand" href="/" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
@@ -22,15 +22,15 @@
       <span class="nav-toggle__label">Menu</span>
     </button>
     <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
-      <a class="nav-link nav-link--home" href="index.html">Strona główna</a>
-      <a class="nav-link nav-link--about" href="onas.html">O nas</a>
-      <a class="nav-link nav-link--gallery" href="galeria.html">Galeria</a>
-      <a class="nav-link nav-link--links" href="linki.html">Linki</a>
+      <a class="nav-link nav-link--home" href="/">Strona główna</a>
+      <a class="nav-link nav-link--about" href="/onas">O nas</a>
+      <a class="nav-link nav-link--gallery" href="/galeria">Galeria</a>
+      <a class="nav-link nav-link--links" href="/linki">Linki</a>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
-      <a class="nav-link" href="sklep/">Sklep</a>
-      <a class="nav-link nav-link--support" href="wesprzyj-nas.html">Wesprzyj nas</a>
-      <a class="nav-link nav-link--contact" href="kontakt.html" aria-current="page">Kontakt</a>
-      <a class="nav-link nav-link--downloads" href="materialy.html">Materiały do pobrania</a>
+      <a class="nav-link" href="/sklep">Sklep</a>
+      <a class="nav-link nav-link--support" href="/wesprzyj-nas">Wesprzyj nas</a>
+      <a class="nav-link nav-link--contact" href="/kontakt" aria-current="page">Kontakt</a>
+      <a class="nav-link nav-link--downloads" href="/materialy">Materiały do pobrania</a>
       <div class="nav-divider" role="presentation"></div>
       <div class="nav-links-section" aria-label="Linki społecznościowe">
         <span class="nav-links-section__title">Linki</span>
@@ -43,13 +43,6 @@
   </header>
 
   <h1 class="site-title">ExploRide.pl</h1>
-
-  <div class="site-title-socials" aria-label="Skróty do social mediów ExploRide">
-    <a class="site-title-socials__button links-button--yt" href="https://www.youtube.com/@ExploRideURBEX" target="_blank" rel="noopener noreferrer">YouTube</a>
-    <a class="site-title-socials__button links-button--fb" href="https://www.facebook.com/ExploRideURBEX" target="_blank" rel="noopener noreferrer">Facebook</a>
-    <a class="site-title-socials__button links-button--ig" href="https://www.instagram.com/exploride.urbex" target="_blank" rel="noopener noreferrer">Instagram</a>
-    <a class="site-title-socials__button links-button--tt" href="https://www.tiktok.com/@exploride.urbex" target="_blank" rel="noopener noreferrer">TikTok</a>
-  </div>
 
     <hr class="divider" />
 

--- a/linki.html
+++ b/linki.html
@@ -11,7 +11,7 @@
 </head>
 <body class="page-links">
   <header data-nav-layout="sidebar">
-    <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
+    <a class="brand" href="/" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
@@ -23,15 +23,15 @@
       <span class="nav-toggle__label">Menu</span>
     </button>
     <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
-      <a class="nav-link nav-link--home" href="index.html">Strona główna</a>
-      <a class="nav-link nav-link--about" href="onas.html">O nas</a>
-      <a class="nav-link nav-link--gallery" href="galeria.html">Galeria</a>
-      <a class="nav-link nav-link--links" href="linki.html" aria-current="page">Linki</a>
+      <a class="nav-link nav-link--home" href="/">Strona główna</a>
+      <a class="nav-link nav-link--about" href="/onas">O nas</a>
+      <a class="nav-link nav-link--gallery" href="/galeria">Galeria</a>
+      <a class="nav-link nav-link--links" href="/linki" aria-current="page">Linki</a>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
-      <a class="nav-link" href="sklep/">Sklep</a>
-      <a class="nav-link nav-link--support" href="wesprzyj-nas.html">Wesprzyj nas</a>
-      <a class="nav-link nav-link--contact" href="kontakt.html">Kontakt</a>
-      <a class="nav-link nav-link--downloads" href="materialy.html">Materiały do pobrania</a>
+      <a class="nav-link" href="/sklep">Sklep</a>
+      <a class="nav-link nav-link--support" href="/wesprzyj-nas">Wesprzyj nas</a>
+      <a class="nav-link nav-link--contact" href="/kontakt">Kontakt</a>
+      <a class="nav-link nav-link--downloads" href="/materialy">Materiały do pobrania</a>
       <div class="nav-divider" role="presentation"></div>
       <div class="nav-links-section" aria-label="Linki społecznościowe">
         <span class="nav-links-section__title">Linki</span>
@@ -44,13 +44,6 @@
   </header>
 
   <h1 class="site-title">ExploRide.pl</h1>
-
-  <div class="site-title-socials" aria-label="Skróty do social mediów ExploRide">
-    <a class="site-title-socials__button links-button--yt" href="https://www.youtube.com/@ExploRideURBEX" target="_blank" rel="noopener noreferrer">YouTube</a>
-    <a class="site-title-socials__button links-button--fb" href="https://www.facebook.com/ExploRideURBEX" target="_blank" rel="noopener noreferrer">Facebook</a>
-    <a class="site-title-socials__button links-button--ig" href="https://www.instagram.com/exploride.urbex" target="_blank" rel="noopener noreferrer">Instagram</a>
-    <a class="site-title-socials__button links-button--tt" href="https://www.tiktok.com/@exploride.urbex" target="_blank" rel="noopener noreferrer">TikTok</a>
-  </div>
 
     <hr class="divider" />
 

--- a/materialy.html
+++ b/materialy.html
@@ -10,7 +10,7 @@
 </head>
 <body class="page-downloads">
   <header data-nav-layout="sidebar">
-    <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
+    <a class="brand" href="/" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
@@ -22,15 +22,15 @@
       <span class="nav-toggle__label">Menu</span>
     </button>
     <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
-      <a class="nav-link nav-link--home" href="index.html">Strona główna</a>
-      <a class="nav-link nav-link--about" href="onas.html">O nas</a>
-      <a class="nav-link nav-link--gallery" href="galeria.html">Galeria</a>
-      <a class="nav-link nav-link--links" href="linki.html">Linki</a>
+      <a class="nav-link nav-link--home" href="/">Strona główna</a>
+      <a class="nav-link nav-link--about" href="/onas">O nas</a>
+      <a class="nav-link nav-link--gallery" href="/galeria">Galeria</a>
+      <a class="nav-link nav-link--links" href="/linki">Linki</a>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
-      <a class="nav-link" href="sklep/">Sklep</a>
-      <a class="nav-link nav-link--support" href="wesprzyj-nas.html">Wesprzyj nas</a>
-      <a class="nav-link nav-link--contact" href="kontakt.html">Kontakt</a>
-      <a class="nav-link nav-link--downloads" href="materialy.html" aria-current="page">Materiały do pobrania</a>
+      <a class="nav-link" href="/sklep">Sklep</a>
+      <a class="nav-link nav-link--support" href="/wesprzyj-nas">Wesprzyj nas</a>
+      <a class="nav-link nav-link--contact" href="/kontakt">Kontakt</a>
+      <a class="nav-link nav-link--downloads" href="/materialy" aria-current="page">Materiały do pobrania</a>
       <div class="nav-divider" role="presentation"></div>
       <div class="nav-links-section" aria-label="Linki społecznościowe">
         <span class="nav-links-section__title">Linki</span>
@@ -43,13 +43,6 @@
   </header>
 
   <h1 class="site-title">ExploRide.pl</h1>
-
-  <div class="site-title-socials" aria-label="Skróty do social mediów ExploRide">
-    <a class="site-title-socials__button links-button--yt" href="https://www.youtube.com/@ExploRideURBEX" target="_blank" rel="noopener noreferrer">YouTube</a>
-    <a class="site-title-socials__button links-button--fb" href="https://www.facebook.com/ExploRideURBEX" target="_blank" rel="noopener noreferrer">Facebook</a>
-    <a class="site-title-socials__button links-button--ig" href="https://www.instagram.com/exploride.urbex" target="_blank" rel="noopener noreferrer">Instagram</a>
-    <a class="site-title-socials__button links-button--tt" href="https://www.tiktok.com/@exploride.urbex" target="_blank" rel="noopener noreferrer">TikTok</a>
-  </div>
 
     <hr class="divider" />
 

--- a/onas.html
+++ b/onas.html
@@ -10,7 +10,7 @@
 </head>
 <body class="page-about">
   <header data-nav-layout="sidebar">
-    <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
+    <a class="brand" href="/" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
@@ -22,15 +22,15 @@
       <span class="nav-toggle__label">Menu</span>
     </button>
     <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
-      <a class="nav-link nav-link--home" href="index.html">Strona główna</a>
-      <a class="nav-link nav-link--about" href="onas.html" aria-current="page">O nas</a>
-      <a class="nav-link nav-link--gallery" href="galeria.html">Galeria</a>
-      <a class="nav-link nav-link--links" href="linki.html">Linki</a>
+      <a class="nav-link nav-link--home" href="/">Strona główna</a>
+      <a class="nav-link nav-link--about" href="/onas" aria-current="page">O nas</a>
+      <a class="nav-link nav-link--gallery" href="/galeria">Galeria</a>
+      <a class="nav-link nav-link--links" href="/linki">Linki</a>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
-      <a class="nav-link" href="sklep/">Sklep</a>
-      <a class="nav-link nav-link--support" href="wesprzyj-nas.html">Wesprzyj nas</a>
-      <a class="nav-link nav-link--contact" href="kontakt.html">Kontakt</a>
-      <a class="nav-link nav-link--downloads" href="materialy.html">Materiały do pobrania</a>
+      <a class="nav-link" href="/sklep">Sklep</a>
+      <a class="nav-link nav-link--support" href="/wesprzyj-nas">Wesprzyj nas</a>
+      <a class="nav-link nav-link--contact" href="/kontakt">Kontakt</a>
+      <a class="nav-link nav-link--downloads" href="/materialy">Materiały do pobrania</a>
       <div class="nav-divider" role="presentation"></div>
       <div class="nav-links-section" aria-label="Linki społecznościowe">
         <span class="nav-links-section__title">Linki</span>
@@ -43,13 +43,6 @@
   </header>
 
   <h1 class="site-title">ExploRide.pl</h1>
-
-  <div class="site-title-socials" aria-label="Skróty do social mediów ExploRide">
-    <a class="site-title-socials__button links-button--yt" href="https://www.youtube.com/@ExploRideURBEX" target="_blank" rel="noopener noreferrer">YouTube</a>
-    <a class="site-title-socials__button links-button--fb" href="https://www.facebook.com/ExploRideURBEX" target="_blank" rel="noopener noreferrer">Facebook</a>
-    <a class="site-title-socials__button links-button--ig" href="https://www.instagram.com/exploride.urbex" target="_blank" rel="noopener noreferrer">Instagram</a>
-    <a class="site-title-socials__button links-button--tt" href="https://www.tiktok.com/@exploride.urbex" target="_blank" rel="noopener noreferrer">TikTok</a>
-  </div>
 
     <hr class="divider" />
 

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -10,7 +10,7 @@
 </head>
 <body class="page-privacy">
   <header data-nav-layout="sidebar">
-    <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
+    <a class="brand" href="/" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
@@ -22,15 +22,15 @@
       <span class="nav-toggle__label">Menu</span>
     </button>
     <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
-      <a class="nav-link nav-link--home" href="index.html">Strona główna</a>
-      <a class="nav-link nav-link--about" href="onas.html">O nas</a>
-      <a class="nav-link nav-link--gallery" href="galeria.html">Galeria</a>
-      <a class="nav-link nav-link--links" href="linki.html">Linki</a>
+      <a class="nav-link nav-link--home" href="/">Strona główna</a>
+      <a class="nav-link nav-link--about" href="/onas">O nas</a>
+      <a class="nav-link nav-link--gallery" href="/galeria">Galeria</a>
+      <a class="nav-link nav-link--links" href="/linki">Linki</a>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
-      <a class="nav-link" href="sklep/">Sklep</a>
-      <a class="nav-link nav-link--support" href="wesprzyj-nas.html">Wesprzyj nas</a>
-      <a class="nav-link nav-link--contact" href="kontakt.html">Kontakt</a>
-      <a class="nav-link nav-link--downloads" href="materialy.html">Materiały do pobrania</a>
+      <a class="nav-link" href="/sklep">Sklep</a>
+      <a class="nav-link nav-link--support" href="/wesprzyj-nas">Wesprzyj nas</a>
+      <a class="nav-link nav-link--contact" href="/kontakt">Kontakt</a>
+      <a class="nav-link nav-link--downloads" href="/materialy">Materiały do pobrania</a>
       <div class="nav-divider" role="presentation"></div>
       <div class="nav-links-section" aria-label="Linki społecznościowe">
         <span class="nav-links-section__title">Linki</span>
@@ -43,13 +43,6 @@
   </header>
 
   <h1 class="site-title">ExploRide.pl</h1>
-
-  <div class="site-title-socials" aria-label="Skróty do social mediów ExploRide">
-    <a class="site-title-socials__button links-button--yt" href="https://www.youtube.com/@ExploRideURBEX" target="_blank" rel="noopener noreferrer">YouTube</a>
-    <a class="site-title-socials__button links-button--fb" href="https://www.facebook.com/ExploRideURBEX" target="_blank" rel="noopener noreferrer">Facebook</a>
-    <a class="site-title-socials__button links-button--ig" href="https://www.instagram.com/exploride.urbex" target="_blank" rel="noopener noreferrer">Instagram</a>
-    <a class="site-title-socials__button links-button--tt" href="https://www.tiktok.com/@exploride.urbex" target="_blank" rel="noopener noreferrer">TikTok</a>
-  </div>
 
     <hr class="divider" />
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,43 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://exploride.pl/index.html</loc>
+    <loc>https://exploride.pl/</loc>
     <lastmod>2025-10-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://exploride.pl/onas.html</loc>
+    <loc>https://exploride.pl/onas</loc>
     <lastmod>2025-10-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://exploride.pl/galeria.html</loc>
+    <loc>https://exploride.pl/galeria</loc>
     <lastmod>2025-10-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://exploride.pl/linki.html</loc>
+    <loc>https://exploride.pl/linki</loc>
     <lastmod>2025-10-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://exploride.pl/wesprzyj-nas.html</loc>
+    <loc>https://exploride.pl/wesprzyj-nas</loc>
     <lastmod>2025-10-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://exploride.pl/kontakt.html</loc>
+    <loc>https://exploride.pl/kontakt</loc>
     <lastmod>2025-10-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://exploride.pl/materialy.html</loc>
+    <loc>https://exploride.pl/materialy</loc>
     <lastmod>2025-10-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>

--- a/sklep/czapka-z-daszkiem-exploride.html
+++ b/sklep/czapka-z-daszkiem-exploride.html
@@ -12,7 +12,7 @@
 </head>
 <body class="page-shop" data-product-slug="czapka-z-daszkiem-exploride">
   <header data-nav-layout="sidebar">
-    <a class="brand" href="../index.html" aria-label="Strona główna ExploRide">
+    <a class="brand" href="/" aria-label="Strona główna ExploRide">
       <img src="../logo.png" alt="ExploRide logo" class="logo">
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
@@ -24,15 +24,15 @@
       <span class="nav-toggle__label">Menu</span>
     </button>
     <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
-      <a class="nav-link nav-link--home" href="../index.html">Strona główna</a>
-      <a class="nav-link nav-link--about" href="../onas.html">O nas</a>
-      <a class="nav-link nav-link--gallery" href="../galeria.html">Galeria</a>
-      <a class="nav-link nav-link--links" href="../linki.html">Linki</a>
+      <a class="nav-link nav-link--home" href="/">Strona główna</a>
+      <a class="nav-link nav-link--about" href="/onas">O nas</a>
+      <a class="nav-link nav-link--gallery" href="/galeria">Galeria</a>
+      <a class="nav-link nav-link--links" href="/linki">Linki</a>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
-      <a class="nav-link" href="./" aria-current="page">Sklep</a>
-      <a class="nav-link nav-link--support" href="../wesprzyj-nas.html">Wesprzyj nas</a>
-      <a class="nav-link nav-link--contact" href="../kontakt.html">Kontakt</a>
-      <a class="nav-link nav-link--downloads" href="../materialy.html">Materiały do pobrania</a>
+      <a class="nav-link" href="/sklep" aria-current="page">Sklep</a>
+      <a class="nav-link nav-link--support" href="/wesprzyj-nas">Wesprzyj nas</a>
+      <a class="nav-link nav-link--contact" href="/kontakt">Kontakt</a>
+      <a class="nav-link nav-link--downloads" href="/materialy">Materiały do pobrania</a>
       <div class="nav-divider" role="presentation"></div>
       <div class="nav-links-section" aria-label="Linki społecznościowe">
         <span class="nav-links-section__title">Linki</span>

--- a/sklep/index.html
+++ b/sklep/index.html
@@ -12,7 +12,7 @@
 </head>
 <body class="page-shop">
   <header data-nav-layout="sidebar">
-    <a class="brand" href="../index.html" aria-label="Strona główna ExploRide">
+    <a class="brand" href="/" aria-label="Strona główna ExploRide">
       <img src="../logo.png" alt="ExploRide logo" class="logo">
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
@@ -24,15 +24,15 @@
       <span class="nav-toggle__label">Menu</span>
     </button>
     <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
-      <a class="nav-link nav-link--home" href="../index.html">Strona główna</a>
-      <a class="nav-link nav-link--about" href="../onas.html">O nas</a>
-      <a class="nav-link nav-link--gallery" href="../galeria.html">Galeria</a>
-      <a class="nav-link nav-link--links" href="../linki.html">Linki</a>
+      <a class="nav-link nav-link--home" href="/">Strona główna</a>
+      <a class="nav-link nav-link--about" href="/onas">O nas</a>
+      <a class="nav-link nav-link--gallery" href="/galeria">Galeria</a>
+      <a class="nav-link nav-link--links" href="/linki">Linki</a>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
-      <a class="nav-link" href="./" aria-current="page">Sklep</a>
-      <a class="nav-link nav-link--support" href="../wesprzyj-nas.html">Wesprzyj nas</a>
-      <a class="nav-link nav-link--contact" href="../kontakt.html">Kontakt</a>
-      <a class="nav-link nav-link--downloads" href="../materialy.html">Materiały do pobrania</a>
+      <a class="nav-link" href="/sklep" aria-current="page">Sklep</a>
+      <a class="nav-link nav-link--support" href="/wesprzyj-nas">Wesprzyj nas</a>
+      <a class="nav-link nav-link--contact" href="/kontakt">Kontakt</a>
+      <a class="nav-link nav-link--downloads" href="/materialy">Materiały do pobrania</a>
       <div class="nav-divider" role="presentation"></div>
       <div class="nav-links-section" aria-label="Linki społecznościowe">
         <span class="nav-links-section__title">Linki</span>

--- a/sklep/kalendarz-2026.html
+++ b/sklep/kalendarz-2026.html
@@ -12,7 +12,7 @@
 </head>
 <body class="page-shop" data-product-slug="kalendarz-2026">
   <header data-nav-layout="sidebar">
-    <a class="brand" href="../index.html" aria-label="Strona główna ExploRide">
+    <a class="brand" href="/" aria-label="Strona główna ExploRide">
       <img src="../logo.png" alt="ExploRide logo" class="logo">
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
@@ -24,15 +24,15 @@
       <span class="nav-toggle__label">Menu</span>
     </button>
     <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
-      <a class="nav-link nav-link--home" href="../index.html">Strona główna</a>
-      <a class="nav-link nav-link--about" href="../onas.html">O nas</a>
-      <a class="nav-link nav-link--gallery" href="../galeria.html">Galeria</a>
-      <a class="nav-link nav-link--links" href="../linki.html">Linki</a>
+      <a class="nav-link nav-link--home" href="/">Strona główna</a>
+      <a class="nav-link nav-link--about" href="/onas">O nas</a>
+      <a class="nav-link nav-link--gallery" href="/galeria">Galeria</a>
+      <a class="nav-link nav-link--links" href="/linki">Linki</a>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
-      <a class="nav-link" href="./" aria-current="page">Sklep</a>
-      <a class="nav-link nav-link--support" href="../wesprzyj-nas.html">Wesprzyj nas</a>
-      <a class="nav-link nav-link--contact" href="../kontakt.html">Kontakt</a>
-      <a class="nav-link nav-link--downloads" href="../materialy.html">Materiały do pobrania</a>
+      <a class="nav-link" href="/sklep" aria-current="page">Sklep</a>
+      <a class="nav-link nav-link--support" href="/wesprzyj-nas">Wesprzyj nas</a>
+      <a class="nav-link nav-link--contact" href="/kontakt">Kontakt</a>
+      <a class="nav-link nav-link--downloads" href="/materialy">Materiały do pobrania</a>
       <div class="nav-divider" role="presentation"></div>
       <div class="nav-links-section" aria-label="Linki społecznościowe">
         <span class="nav-links-section__title">Linki</span>

--- a/sklep/t-shirt-damski-classic.html
+++ b/sklep/t-shirt-damski-classic.html
@@ -12,7 +12,7 @@
 </head>
 <body class="page-shop" data-product-slug="t-shirt-damski-classic">
   <header data-nav-layout="sidebar">
-    <a class="brand" href="../index.html" aria-label="Strona główna ExploRide">
+    <a class="brand" href="/" aria-label="Strona główna ExploRide">
       <img src="../logo.png" alt="ExploRide logo" class="logo">
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
@@ -24,15 +24,15 @@
       <span class="nav-toggle__label">Menu</span>
     </button>
     <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
-      <a class="nav-link nav-link--home" href="../index.html">Strona główna</a>
-      <a class="nav-link nav-link--about" href="../onas.html">O nas</a>
-      <a class="nav-link nav-link--gallery" href="../galeria.html">Galeria</a>
-      <a class="nav-link nav-link--links" href="../linki.html">Linki</a>
+      <a class="nav-link nav-link--home" href="/">Strona główna</a>
+      <a class="nav-link nav-link--about" href="/onas">O nas</a>
+      <a class="nav-link nav-link--gallery" href="/galeria">Galeria</a>
+      <a class="nav-link nav-link--links" href="/linki">Linki</a>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
-      <a class="nav-link" href="./" aria-current="page">Sklep</a>
-      <a class="nav-link nav-link--support" href="../wesprzyj-nas.html">Wesprzyj nas</a>
-      <a class="nav-link nav-link--contact" href="../kontakt.html">Kontakt</a>
-      <a class="nav-link nav-link--downloads" href="../materialy.html">Materiały do pobrania</a>
+      <a class="nav-link" href="/sklep" aria-current="page">Sklep</a>
+      <a class="nav-link nav-link--support" href="/wesprzyj-nas">Wesprzyj nas</a>
+      <a class="nav-link nav-link--contact" href="/kontakt">Kontakt</a>
+      <a class="nav-link nav-link--downloads" href="/materialy">Materiały do pobrania</a>
       <div class="nav-divider" role="presentation"></div>
       <div class="nav-links-section" aria-label="Linki społecznościowe">
         <span class="nav-links-section__title">Linki</span>

--- a/sklep/t-shirt-meski-classic.html
+++ b/sklep/t-shirt-meski-classic.html
@@ -12,7 +12,7 @@
 </head>
 <body class="page-shop" data-product-slug="t-shirt-meski-classic">
   <header data-nav-layout="sidebar">
-    <a class="brand" href="../index.html" aria-label="Strona główna ExploRide">
+    <a class="brand" href="/" aria-label="Strona główna ExploRide">
       <img src="../logo.png" alt="ExploRide logo" class="logo">
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
@@ -24,15 +24,15 @@
       <span class="nav-toggle__label">Menu</span>
     </button>
     <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
-      <a class="nav-link nav-link--home" href="../index.html">Strona główna</a>
-      <a class="nav-link nav-link--about" href="../onas.html">O nas</a>
-      <a class="nav-link nav-link--gallery" href="../galeria.html">Galeria</a>
-      <a class="nav-link nav-link--links" href="../linki.html">Linki</a>
+      <a class="nav-link nav-link--home" href="/">Strona główna</a>
+      <a class="nav-link nav-link--about" href="/onas">O nas</a>
+      <a class="nav-link nav-link--gallery" href="/galeria">Galeria</a>
+      <a class="nav-link nav-link--links" href="/linki">Linki</a>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
-      <a class="nav-link" href="./" aria-current="page">Sklep</a>
-      <a class="nav-link nav-link--support" href="../wesprzyj-nas.html">Wesprzyj nas</a>
-      <a class="nav-link nav-link--contact" href="../kontakt.html">Kontakt</a>
-      <a class="nav-link nav-link--downloads" href="../materialy.html">Materiały do pobrania</a>
+      <a class="nav-link" href="/sklep" aria-current="page">Sklep</a>
+      <a class="nav-link nav-link--support" href="/wesprzyj-nas">Wesprzyj nas</a>
+      <a class="nav-link nav-link--contact" href="/kontakt">Kontakt</a>
+      <a class="nav-link nav-link--downloads" href="/materialy">Materiały do pobrania</a>
       <div class="nav-divider" role="presentation"></div>
       <div class="nav-links-section" aria-label="Linki społecznościowe">
         <span class="nav-links-section__title">Linki</span>

--- a/wesprzyj-nas.html
+++ b/wesprzyj-nas.html
@@ -10,7 +10,7 @@
 </head>
 <body class="page-support">
   <header data-nav-layout="sidebar">
-    <a class="brand" href="index.html" aria-label="Strona główna ExploRide">
+    <a class="brand" href="/" aria-label="Strona główna ExploRide">
       <img src="logo.png" alt="ExploRide logo" class="logo">
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="main-navigation">
@@ -22,15 +22,15 @@
       <span class="nav-toggle__label">Menu</span>
     </button>
     <nav class="top-nav" id="main-navigation" aria-label="Główna nawigacja">
-      <a class="nav-link nav-link--home" href="index.html">Strona główna</a>
-      <a class="nav-link nav-link--about" href="onas.html">O nas</a>
-      <a class="nav-link nav-link--gallery" href="galeria.html">Galeria</a>
-      <a class="nav-link nav-link--links" href="linki.html">Linki</a>
+      <a class="nav-link nav-link--home" href="/">Strona główna</a>
+      <a class="nav-link nav-link--about" href="/onas">O nas</a>
+      <a class="nav-link nav-link--gallery" href="/galeria">Galeria</a>
+      <a class="nav-link nav-link--links" href="/linki">Linki</a>
       <button class="nav-link nav-link--disabled" type="button" disabled title="Wkrótce dostępne">Blog</button>
-      <a class="nav-link" href="sklep/">Sklep</a>
-      <a class="nav-link nav-link--support" href="wesprzyj-nas.html" aria-current="page">Wesprzyj nas</a>
-      <a class="nav-link nav-link--contact" href="kontakt.html">Kontakt</a>
-      <a class="nav-link nav-link--downloads" href="materialy.html">Materiały do pobrania</a>
+      <a class="nav-link" href="/sklep">Sklep</a>
+      <a class="nav-link nav-link--support" href="/wesprzyj-nas" aria-current="page">Wesprzyj nas</a>
+      <a class="nav-link nav-link--contact" href="/kontakt">Kontakt</a>
+      <a class="nav-link nav-link--downloads" href="/materialy">Materiały do pobrania</a>
       <div class="nav-divider" role="presentation"></div>
       <div class="nav-links-section" aria-label="Linki społecznościowe">
         <span class="nav-links-section__title">Linki</span>
@@ -43,13 +43,6 @@
   </header>
 
   <h1 class="site-title">ExploRide.pl</h1>
-
-  <div class="site-title-socials" aria-label="Skróty do social mediów ExploRide">
-    <a class="site-title-socials__button links-button--yt" href="https://www.youtube.com/@ExploRideURBEX" target="_blank" rel="noopener noreferrer">YouTube</a>
-    <a class="site-title-socials__button links-button--fb" href="https://www.facebook.com/ExploRideURBEX" target="_blank" rel="noopener noreferrer">Facebook</a>
-    <a class="site-title-socials__button links-button--ig" href="https://www.instagram.com/exploride.urbex" target="_blank" rel="noopener noreferrer">Instagram</a>
-    <a class="site-title-socials__button links-button--tt" href="https://www.tiktok.com/@exploride.urbex" target="_blank" rel="noopener noreferrer">TikTok</a>
-  </div>
 
     <hr class="divider" />
 


### PR DESCRIPTION
### Motivation
- Make primary navigation and brand links use clean extensionless paths so browser URLs show `/` or `/onas` instead of `/index.html` or `/onas.html`.
- Show the `.site-title-socials` social button row only on the homepage and remove it from subpages for a cleaner header on inner pages.

### Description
- Replaced header/brand and navigation `href` values across site pages with extensionless paths (e.g. `href="/"`, `href="/onas"`, `href="/galeria"`, `href="/sklep"`).
- Removed the `<div class="site-title-socials">` block from all HTML files except `index.html` so social buttons appear only on the homepage.
- Adjusted shop subpages to use root-based links (brand `href="/"` and shop index `href="/sklep"`) and normalized internal shop navigation.
- Updated `sitemap.xml` entries to the canonical extensionless URLs (e.g. `https://exploride.pl/onas`).

### Testing
- Ran a Python validation that checked no subpage contains `.site-title-socials` and that header/brand nav links do not contain `.html`, and the script reported success.
- Parsed `sitemap.xml` with `xml.etree.ElementTree` and it was reported as well-formed XML.
- Ran `git diff --check` for whitespace/merge issues and it reported no problems.
- Attempted a visual check with Playwright using `npx playwright screenshot --browser=chromium "file://$(pwd)/onas.html"`, but browser installation failed due to CDN download errors (`403 Domain forbidden`) so the screenshot step did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a194deccbe8833092150533532247aa)