### PR TITLE
Show title social links on desktop subpages and hide on mobile

### DIFF
--- a/galeria.html
+++ b/galeria.html
@@ -44,6 +44,13 @@
 
   <h1 class="site-title">ExploRide.pl</h1>
 
+  <div class="site-title-socials" aria-label="Skróty do social mediów ExploRide">
+    <a class="site-title-socials__button links-button--yt" href="https://www.youtube.com/@ExploRideURBEX" target="_blank" rel="noopener noreferrer">YouTube</a>
+    <a class="site-title-socials__button links-button--fb" href="https://www.facebook.com/ExploRideURBEX" target="_blank" rel="noopener noreferrer">Facebook</a>
+    <a class="site-title-socials__button links-button--ig" href="https://www.instagram.com/exploride.urbex" target="_blank" rel="noopener noreferrer">Instagram</a>
+    <a class="site-title-socials__button links-button--tt" href="https://www.tiktok.com/@exploride.urbex" target="_blank" rel="noopener noreferrer">TikTok</a>
+  </div>
+
     <hr class="divider" />
 
   <main class="gallery-main">

--- a/kontakt.html
+++ b/kontakt.html
@@ -44,6 +44,13 @@
 
   <h1 class="site-title">ExploRide.pl</h1>
 
+  <div class="site-title-socials" aria-label="Skróty do social mediów ExploRide">
+    <a class="site-title-socials__button links-button--yt" href="https://www.youtube.com/@ExploRideURBEX" target="_blank" rel="noopener noreferrer">YouTube</a>
+    <a class="site-title-socials__button links-button--fb" href="https://www.facebook.com/ExploRideURBEX" target="_blank" rel="noopener noreferrer">Facebook</a>
+    <a class="site-title-socials__button links-button--ig" href="https://www.instagram.com/exploride.urbex" target="_blank" rel="noopener noreferrer">Instagram</a>
+    <a class="site-title-socials__button links-button--tt" href="https://www.tiktok.com/@exploride.urbex" target="_blank" rel="noopener noreferrer">TikTok</a>
+  </div>
+
     <hr class="divider" />
 
   <main class="contact-main">

--- a/onas.html
+++ b/onas.html
@@ -44,6 +44,13 @@
 
   <h1 class="site-title">ExploRide.pl</h1>
 
+  <div class="site-title-socials" aria-label="Skróty do social mediów ExploRide">
+    <a class="site-title-socials__button links-button--yt" href="https://www.youtube.com/@ExploRideURBEX" target="_blank" rel="noopener noreferrer">YouTube</a>
+    <a class="site-title-socials__button links-button--fb" href="https://www.facebook.com/ExploRideURBEX" target="_blank" rel="noopener noreferrer">Facebook</a>
+    <a class="site-title-socials__button links-button--ig" href="https://www.instagram.com/exploride.urbex" target="_blank" rel="noopener noreferrer">Instagram</a>
+    <a class="site-title-socials__button links-button--tt" href="https://www.tiktok.com/@exploride.urbex" target="_blank" rel="noopener noreferrer">TikTok</a>
+  </div>
+
     <hr class="divider" />
 
   <main class="about-main">

--- a/style.css
+++ b/style.css
@@ -493,13 +493,6 @@
       }
 
       .site-title-socials {
-        justify-content: center;
-        margin: clamp(4px, 1.8vw, 8px) auto 0;
-        padding: 0 12px;
-        overflow: visible;
-      }
-
-      .site-title-socials__button {
         display: none;
       }
 

--- a/wesprzyj-nas.html
+++ b/wesprzyj-nas.html
@@ -44,6 +44,13 @@
 
   <h1 class="site-title">ExploRide.pl</h1>
 
+  <div class="site-title-socials" aria-label="Skróty do social mediów ExploRide">
+    <a class="site-title-socials__button links-button--yt" href="https://www.youtube.com/@ExploRideURBEX" target="_blank" rel="noopener noreferrer">YouTube</a>
+    <a class="site-title-socials__button links-button--fb" href="https://www.facebook.com/ExploRideURBEX" target="_blank" rel="noopener noreferrer">Facebook</a>
+    <a class="site-title-socials__button links-button--ig" href="https://www.instagram.com/exploride.urbex" target="_blank" rel="noopener noreferrer">Instagram</a>
+    <a class="site-title-socials__button links-button--tt" href="https://www.tiktok.com/@exploride.urbex" target="_blank" rel="noopener noreferrer">TikTok</a>
+  </div>
+
     <hr class="divider" />
 
   <main class="support-main">


### PR DESCRIPTION
### Motivation
- Make the `.site-title-socials` social-links block visible not only on the homepage but also on the About, Support, Gallery and Contact subpages for desktop view. 
- Ensure the component remains hidden on all mobile viewports to avoid duplicate or cluttered UI on small screens.

### Description
- Inserted the `.site-title-socials` HTML block (YouTube, Facebook, Instagram, TikTok links) immediately after the main `h1.site-title` in `onas.html`, `wesprzyj-nas.html`, `galeria.html`, and `kontakt.html`.
- Updated `style.css` mobile media rule to hide the entire `.site-title-socials` container on `@media (max-width: 767px)` by setting `.site-title-socials { display: none; }`.
- Removed the previous mobile-specific rules that partially hid buttons so the behavior is now: visible on desktop pages and fully hidden on mobile.

### Testing
- Ran a `python3` assertion script that verified each target page contains `class="site-title-socials"` in the expected position and that the mobile CSS contains `.site-title-socials { display: none; }`, and it passed.
- Served the site with `python3 -m http.server` and confirmed the `HEAD` response for `onas.html` with `curl -I` returned `200 OK`.
- Attempted automated visual checks with Playwright screenshots, but Playwright browser installation failed due to a CDN HTTP 403 in this environment, so the screenshot step did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a194f8349ec8330a7a6865a9cface85)