### PR TITLE
Dodaj nagłówek ExploRide.pl i separator na stronach sklepu

### DIFF
--- a/sklep/czapka-z-daszkiem-exploride.html
+++ b/sklep/czapka-z-daszkiem-exploride.html
@@ -44,6 +44,10 @@
     </nav>
   </header>
 
+  <h1 class="site-title">ExploRide.pl</h1>
+
+  <hr class="divider" />
+
   <div class="shop-hero shop-hero--compact">
     <div class="shop-cart-banner">
       <div class="shop-cart-banner__info">

--- a/sklep/index.html
+++ b/sklep/index.html
@@ -44,6 +44,10 @@
     </nav>
   </header>
 
+  <h1 class="site-title">ExploRide.pl</h1>
+
+  <hr class="divider" />
+
   <div class="shop-hero">
     <div class="shop-cart-banner">
       <div class="shop-cart-banner__info">

--- a/sklep/kalendarz-2026.html
+++ b/sklep/kalendarz-2026.html
@@ -44,6 +44,10 @@
     </nav>
   </header>
 
+  <h1 class="site-title">ExploRide.pl</h1>
+
+  <hr class="divider" />
+
   <div class="shop-hero shop-hero--compact">
     <div class="shop-cart-banner">
       <div class="shop-cart-banner__info">

--- a/sklep/t-shirt-damski-classic.html
+++ b/sklep/t-shirt-damski-classic.html
@@ -44,6 +44,10 @@
     </nav>
   </header>
 
+  <h1 class="site-title">ExploRide.pl</h1>
+
+  <hr class="divider" />
+
   <div class="shop-hero shop-hero--compact">
     <div class="shop-cart-banner">
       <div class="shop-cart-banner__info">

--- a/sklep/t-shirt-meski-classic.html
+++ b/sklep/t-shirt-meski-classic.html
@@ -44,6 +44,10 @@
     </nav>
   </header>
 
+  <h1 class="site-title">ExploRide.pl</h1>
+
+  <hr class="divider" />
+
   <div class="shop-hero shop-hero--compact">
     <div class="shop-cart-banner">
       <div class="shop-cart-banner__info">


### PR DESCRIPTION
### Motivation
- Zapewnić spójność nagłówka i separatora między stroną główną a podstronami sekcji `/sklep`, aby marka była widoczna również na stronach sklepu.

### Description
- Wstawiono przed sekcją hero element ` <h1 class="site-title">ExploRide.pl</h1>` oraz `<hr class="divider" />` w plikach: `sklep/index.html`, `sklep/kalendarz-2026.html`, `sklep/t-shirt-meski-classic.html`, `sklep/t-shirt-damski-classic.html` i `sklep/czapka-z-daszkiem-exploride.html`.
- Zmiana jest czysto prezentacyjna i nie modyfikuje logiki skryptów ani stylów istniejących w `style.css` i `main.js`.
- Pliki produktu zachowują swoje metadane i zachowanie, a nagłówek dodano tylko raz przed blokiem `.shop-hero` w każdej strony.

### Testing
- Uruchomiono kontrolę składni i konfliktów z `git diff --check`, która nie zgłosiła problemów.
- Lokalnie wystawiono serwis poleceniem `python3 -m http.server` i potwierdzono obecność nowego nagłówka w odpowiedzi HTTP za pomocą `curl -I http://127.0.0.1:8000/sklep/` oraz `curl -s ... | sed -n '42,56p'`.
- Próba zrobienia zrzutu ekranu z `npx --yes playwright@latest screenshot ...` nie powiodła się, ponieważ instalacja przeglądarki przez Playwright zakończyła się błędem pobierania (`403 Domain forbidden`), więc zrzutu nie wykonano.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a195270fcd08330a58253875f449a86)