### PR TITLE
Keep shop cart banner fixed to viewport during scrolling

### DIFF
--- a/style.css
+++ b/style.css
@@ -2800,17 +2800,23 @@
   border-color: rgba(255, 255, 255, 0.28);
 }
 
+.page-shop {
+  --shop-cart-banner-top: clamp(12px, 4vw, 24px);
+  --shop-cart-banner-reserved-space: 92px;
+  --shop-cart-page-offset: calc(var(--sidebar-width) + clamp(16px, 4vw, 40px) + var(--nav-scrollbar-reserve));
+}
+
 .page-shop .shop-hero {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 32px 24px 12px;
+  padding: calc(32px + var(--shop-cart-banner-reserved-space)) 24px 12px;
   display: flex;
   flex-direction: column;
   gap: 18px;
 }
 
 .shop-hero--compact {
-  padding-block-start: 24px;
+  padding-block-start: calc(24px + var(--shop-cart-banner-reserved-space));
 }
 
 .shop-hero__text {
@@ -2851,9 +2857,14 @@
   justify-content: space-between;
   gap: 16px;
   box-shadow: 0 18px 44px rgba(0, 0, 0, 0.35);
-  position: sticky;
-  top: clamp(12px, 4vw, 24px);
-  z-index: 5;
+  position: fixed;
+  top: var(--shop-cart-banner-top);
+  left: calc(var(--shop-cart-page-offset) + 24px);
+  right: 24px;
+  width: auto;
+  max-width: 1152px;
+  margin-inline: auto;
+  z-index: 20;
 }
 
 .shop-cart-banner__info {
@@ -3564,6 +3575,10 @@ body.is-modal-open {
     margin-top: 4px;
   }
 
+  .page-shop {
+    --shop-cart-banner-reserved-space: 148px;
+  }
+
   .shop-cart-banner {
     flex-direction: column;
     align-items: flex-start;
@@ -3572,6 +3587,19 @@ body.is-modal-open {
   .shop-modal__panel {
     max-height: none;
     height: auto;
+  }
+}
+
+@media (max-width: 767px) {
+  .page-shop {
+    --shop-cart-banner-top: calc(var(--mobile-header-height) + 12px);
+    --shop-cart-banner-reserved-space: 150px;
+    --shop-cart-page-offset: 0px;
+  }
+
+  .shop-cart-banner {
+    left: 16px;
+    right: 16px;
   }
 }
 


### PR DESCRIPTION
### Motivation
- The cart banner used `position: sticky` and became hidden once the hero/parent section scrolled out of range, so it must follow the viewport until the end of the page.
- Prevent page content from jumping underneath the fixed banner by reserving space in the hero area and providing responsive offsets for mobile headers.

### Description
- Converted the cart banner from `position: sticky` to `position: fixed` and set `top`, `left`, `right`, `max-width` and a higher `z-index` in `style.css` so it stays visible in the viewport.
- Introduced CSS variables `--shop-cart-banner-top`, `--shop-cart-banner-reserved-space` and `--shop-cart-page-offset` and increased `.page-shop .shop-hero` padding to reserve space so underlying content does not overlap the fixed banner.
- Added responsive rules (tablet/mobile breakpoints) to adjust the banner top offset and left/right spacing so it sits below the mobile header and adapts to narrow viewports.
- Kept layout behavior for compact/stacked banner on small screens by switching the banner to column layout inside the existing media queries.

### Testing
- Ran `git diff --check` to ensure no trailing whitespace or obvious diff issues and it succeeded.
- Ran a quick CSS sanity check with `python3 - <<'PY' ... PY` which validated brace counts and confirmed the fixed rule was present, and it succeeded.
- Served the site with `python3 -m http.server` and verified the shop page header with `curl -I http://127.0.0.1:8000/sklep/`, which returned `200 OK`.
- Attempted an automated full-page screenshot using Playwright, but browser installation failed due to Playwright CDN returning `403 Domain forbidden`, so the screenshot step could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19548e18b48330af2ad2b8beec221d)