### PR TITLE
Fix mobile header navigation

### DIFF
--- a/main.js
+++ b/main.js
@@ -209,9 +209,19 @@
 
   function initMobileTitleNav() {
     const header = document.querySelector('header');
-    const titleSocials = document.querySelector('.site-title-socials');
-    if (!header || !titleSocials) {
+    if (!header) {
       return;
+    }
+
+    let titleSocials = document.querySelector('.site-title-socials');
+    if (!titleSocials) {
+      titleSocials = document.createElement('div');
+      titleSocials.className = 'site-title-socials site-title-socials--mobile-only';
+      titleSocials.setAttribute('aria-label', 'Skróty nawigacji strony');
+
+      const siteTitle = document.querySelector('.site-title');
+      const anchor = siteTitle || header;
+      anchor.insertAdjacentElement('afterend', titleSocials);
     }
 
     const sourceNav = header.querySelector('.top-nav');

--- a/style.css
+++ b/style.css
@@ -275,6 +275,10 @@
       white-space: nowrap;
     }
 
+    .site-title-socials--mobile-only {
+      display: none;
+    }
+
     .site-title-socials__button:hover,
     .site-title-socials__button:focus-visible {
       transform: translateY(-2px);
@@ -493,6 +497,14 @@
       }
 
       .site-title-socials {
+        display: flex;
+        width: 100%;
+        margin: clamp(4px, 1.6vw, 8px) auto 0;
+        padding: 0 clamp(8px, 3vw, 14px);
+        overflow: visible;
+      }
+
+      .site-title-socials__button {
         display: none;
       }
 
@@ -639,13 +651,10 @@
         color: #e50914;
         outline: none;
       }
-      .page-home header .logo {
-        width: clamp(52px, 16vw, 82px);
-        margin-bottom: 1px;
-      }
       header .logo {
         display: block;
-        width: clamp(48px, 16vw, 76px);
+        width: clamp(52px, 16vw, 82px);
+        margin-bottom: 1px;
       }
       .nav-toggle {
         display: inline-flex;


### PR DESCRIPTION
### Motivation
- Mobile pages lost the shortcut buttons under the header and subpage logos were misaligned compared to the homepage, so mobile navigation UX needed restoring and visual consistency across pages.

### Description
- Reintroduced the mobile shortcuts container by ensuring `.site-title-socials` is shown on small screens and desktop social buttons are hidden via `style.css`.
- Made `initMobileTitleNav` (in `main.js`) create a mobile-only `.site-title-socials` container when a page lacks the desktop social row so mobile shortcut buttons appear on subpages as well.
- Kept the mobile title nav behaviour of showing `primaryCount = 4` direct buttons and moving remaining links into a `Więcej` overflow menu in `main.js`.
- Aligned mobile logo sizing on subpages by unifying the mobile `header .logo` size and bottom margin in `style.css`.

### Testing
- Ran `node --check main.js` to validate JS syntax and it succeeded.
- Executed a small `python3` static assertion script that checked presence of the new CSS and JS identifiers and it passed.
- Served pages and verified HTTP response headers with `curl -I http://127.0.0.1:8000/linki.html` which returned `200 OK`.
- Attempted `npx playwright install chromium` to capture visual screenshots but the browser download failed (Playwright CDN returned `403 Domain forbidden`), so no automated browser screenshots were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19563f3bd88330bed4a3dcab214583)