### PR TITLE
Center link page button content on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -1819,6 +1819,7 @@
 
       .links-buttons .links-button {
         flex: 1 1 100%;
+        justify-content: center;
         max-width: 100%;
       }
 


### PR DESCRIPTION
### Motivation
- On the `linki.html` page the button content remained left-aligned on small screens, so the mobile UX needs the button contents centered.

### Description
- Add `justify-content: center` to the `.links-buttons .links-button` rule inside the `@media (max-width: 720px)` block in `style.css` to horizontally center button content on mobile.

### Testing
- Ran `git diff --check`, served the site and ran `curl -I http://127.0.0.1:4173/linki.html`, and executed a Python assertion that the new CSS rule is present, all of which passed; `npx playwright install chromium` was attempted but failed due to a CDN 403 during browser download.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a195aab591883308bd0f7f979c2ab95)