### PR TITLE
Move shop cart banner below site title

### DIFF
--- a/style.css
+++ b/style.css
@@ -2812,21 +2812,19 @@
 
 .page-shop {
   --shop-cart-banner-top: clamp(12px, 4vw, 24px);
-  --shop-cart-banner-reserved-space: 92px;
-  --shop-cart-page-offset: calc(var(--sidebar-width) + clamp(16px, 4vw, 40px) + var(--nav-scrollbar-reserve));
 }
 
 .page-shop .shop-hero {
   max-width: 1200px;
   margin: 0 auto;
-  padding: calc(32px + var(--shop-cart-banner-reserved-space)) 24px 12px;
+  padding: 24px 24px 12px;
   display: flex;
   flex-direction: column;
   gap: 18px;
 }
 
 .shop-hero--compact {
-  padding-block-start: calc(24px + var(--shop-cart-banner-reserved-space));
+  padding-block-start: 18px;
 }
 
 .shop-hero__text {
@@ -2867,13 +2865,9 @@
   justify-content: space-between;
   gap: 16px;
   box-shadow: 0 18px 44px rgba(0, 0, 0, 0.35);
-  position: fixed;
+  position: sticky;
   top: var(--shop-cart-banner-top);
-  left: calc(var(--shop-cart-page-offset) + 24px);
-  right: 24px;
-  width: auto;
-  max-width: 1152px;
-  margin-inline: auto;
+  width: 100%;
   z-index: 20;
 }
 
@@ -3610,10 +3604,6 @@ body.is-modal-open {
     margin-top: 4px;
   }
 
-  .page-shop {
-    --shop-cart-banner-reserved-space: 148px;
-  }
-
   .shop-cart-banner {
     flex-direction: column;
     align-items: flex-start;
@@ -3628,13 +3618,6 @@ body.is-modal-open {
 @media (max-width: 767px) {
   .page-shop {
     --shop-cart-banner-top: calc(var(--mobile-header-height) + 12px);
-    --shop-cart-banner-reserved-space: 150px;
-    --shop-cart-page-offset: 0px;
-  }
-
-  .shop-cart-banner {
-    left: 16px;
-    right: 16px;
   }
 }
 


### PR DESCRIPTION
### Motivation
- The shop cart banner was overlapping the page title and separator, so the layout must place the banner below the `ExploRide.pl` title without obscuring it.

### Description
- Change `.shop-cart-banner` from `position: fixed` to `position: sticky` and make it full-width to participate in normal page flow while keeping `top: var(--shop-cart-banner-top)`.
- Remove the fixed-position spacing variables `--shop-cart-banner-reserved-space` and `--shop-cart-page-offset` and their usage so the hero section no longer reserves artificial top space.
- Reduce the shop hero padding by setting `.page-shop .shop-hero` to `padding: 24px 24px 12px` and `.shop-hero--compact` to `padding-block-start: 18px` to restore natural spacing below the title.
- Preserve the mobile sticky offset by keeping the mobile `--shop-cart-banner-top: calc(var(--mobile-header-height) + 12px)` rule and adjust responsive banner layout to column direction on smaller screens.

### Testing
- Ran `curl -I http://127.0.0.1:8000/sklep/` and a Python check that confirmed `position: sticky;` is present and `--shop-cart-banner-reserved-space` was removed, which passed.
- Ran `git diff --check` to validate whitespace/format issues, which passed.
- Attempted to install Playwright and download Chromium for visual verification, but the browser download failed with a `403 Domain forbidden` from the Playwright CDN, so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27cb0e4adc8330818b1d17de8448ac)