### PR TITLE
Popraw formularz dostawy: wybór sposobu dostawy i pola warunkowe

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -342,7 +342,14 @@
     return true;
   };
 
-  const sendOrderEmail = async ({ customerName, customerEmail, customerPhone, deliveryAddress, items, total, message }) => {
+  const DELIVERY_METHOD_LABELS = {
+    pickup_point: 'Paczkomat / punkt odbioru',
+    home_delivery: 'Dostawa do domu'
+  };
+
+  const getDeliveryMethodLabel = (value) => DELIVERY_METHOD_LABELS[value] || '';
+
+  const sendOrderEmail = async ({ customerName, customerEmail, customerPhone, deliveryMethod, deliveryAddress, pickupPoint, items, total, message }) => {
     const emailjs = await loadEmailJs();
     if (!emailjs || typeof emailjs.send !== 'function') {
       throw new Error('EmailJS nie jest dostępny.');
@@ -355,7 +362,9 @@
         customer_name: customerName,
         customer_email: customerEmail,
         customer_phone: customerPhone,
+        delivery_method: deliveryMethod,
         delivery_address: deliveryAddress,
+        pickup_point: pickupPoint,
         items,
         total,
         message
@@ -574,6 +583,54 @@
     });
   };
 
+  const updateDeliveryFields = (form) => {
+    if (!form) return;
+
+    const selectedMethod = form.elements.delivery_method?.value || '';
+    const addressField = form.querySelector('[data-delivery-address-field]');
+    const pickupField = form.querySelector('[data-pickup-point-field]');
+    const addressInput = form.elements.delivery_address;
+    const pickupInput = form.elements.pickup_point;
+    const showAddress = selectedMethod === 'home_delivery';
+    const showPickupPoint = selectedMethod === 'pickup_point';
+
+    if (addressField) addressField.hidden = !showAddress;
+    if (pickupField) pickupField.hidden = !showPickupPoint;
+
+    if (addressInput) {
+      addressInput.required = showAddress;
+      if (!showAddress) {
+        addressInput.value = '';
+        addressInput.setCustomValidity('');
+      }
+    }
+
+    if (pickupInput) {
+      pickupInput.required = showPickupPoint;
+      if (!showPickupPoint) {
+        pickupInput.value = '';
+        pickupInput.setCustomValidity('');
+      }
+    }
+  };
+
+  const setupDeliveryFields = (form) => {
+    if (!form || form.dataset.deliveryFieldsBound) return;
+
+    form.querySelectorAll('[name="delivery_method"]').forEach((radio) => {
+      radio.addEventListener('change', () => updateDeliveryFields(form));
+    });
+
+    [form.elements.delivery_address, form.elements.pickup_point].forEach((field) => {
+      if (field && 'setCustomValidity' in field) {
+        field.addEventListener('input', () => field.setCustomValidity(''));
+      }
+    });
+
+    form.dataset.deliveryFieldsBound = 'true';
+    updateDeliveryFields(form);
+  };
+
   const addToCart = ({ id, quantity = 1, size }) => {
     const product = PRODUCTS[id];
     if (!product) return;
@@ -639,6 +696,8 @@
     const modal = document.querySelector('[data-cart-modal]');
     if (!modal) return;
 
+    modal.querySelectorAll('[data-cart-details-form]').forEach(setupDeliveryFields);
+
     modal.querySelectorAll('[data-close-cart]').forEach((btn) => {
       btn.addEventListener('click', closeCart);
     });
@@ -663,6 +722,7 @@
         const form = modal.querySelector('[data-cart-details-form]');
         const status = modal.querySelector('[data-cart-form-status]');
         if (!form) return;
+        setupDeliveryFields(form);
 
         const gdprConsentField = form.elements.gdprConsent;
         if (gdprConsentField && !gdprConsentField.dataset.validationBound) {
@@ -697,6 +757,28 @@
           );
         }
 
+        updateDeliveryFields(form);
+
+        const deliveryMethodForSubmit = form.elements.delivery_method?.value || '';
+        const deliveryAddressForSubmit = form.elements.delivery_address;
+        const pickupPointForSubmit = form.elements.pickup_point;
+
+        if (deliveryAddressForSubmit && 'setCustomValidity' in deliveryAddressForSubmit) {
+          deliveryAddressForSubmit.setCustomValidity(
+            deliveryMethodForSubmit === 'home_delivery' && !deliveryAddressForSubmit.value.trim()
+              ? 'Uzupełnij wymagane pole: Adres dostawy.'
+              : ''
+          );
+        }
+
+        if (pickupPointForSubmit && 'setCustomValidity' in pickupPointForSubmit) {
+          pickupPointForSubmit.setCustomValidity(
+            deliveryMethodForSubmit === 'pickup_point' && !pickupPointForSubmit.value.trim()
+              ? 'Uzupełnij wymagane pole: Paczkomat / punkt odbioru.'
+              : ''
+          );
+        }
+
         if (!form.reportValidity()) return;
 
         const items = buildOrderItems();
@@ -714,11 +796,13 @@
         );
 
         const formData = new FormData(form);
+        const deliveryMethod = String(formData.get('delivery_method') || '').trim();
         const payload = {
           customerName: String(formData.get('customerName') || '').trim(),
           customerEmail: String(formData.get('customerEmail') || '').trim(),
           customerPhone: String(formData.get('customerPhone') || '').trim(),
           delivery_address: String(formData.get('delivery_address') || '').trim(),
+          pickup_point: String(formData.get('pickup_point') || '').trim(),
           message: String(formData.get('message') || '').trim(),
           items,
           total: totalFromState > 0 ? totalFromState : totalFromUI
@@ -737,7 +821,9 @@
               customerName: payload.customerName,
               customerEmail: payload.customerEmail,
               customerPhone: payload.customerPhone,
+              deliveryMethod: getDeliveryMethodLabel(deliveryMethod),
               deliveryAddress: payload.delivery_address,
+              pickupPoint: payload.pickup_point,
               items: itemsSummary,
               total: totalSummary,
               message: payload.message
@@ -751,6 +837,7 @@
           renderCartList();
           updateSummaryUI();
           form.reset();
+          updateDeliveryFields(form);
           closeCart();
           openSuccessModal();
         } catch (error) {

--- a/sklep/czapka-z-daszkiem-exploride.html
+++ b/sklep/czapka-z-daszkiem-exploride.html
@@ -166,9 +166,32 @@
                 <span>Telefon *</span>
                 <input type="tel" name="customerPhone" required autocomplete="tel">
               </label>
+              <fieldset class="cart-details-form__fieldset" data-delivery-method-fieldset>
+                <legend>Sposób dostawy *</legend>
+                <label class="cart-details-form__radio">
+                  <input type="radio" name="delivery_method" value="pickup_point" required>
+                  <span>Paczkomat / punkt odbioru</span>
+                </label>
+                <label class="cart-details-form__radio">
+                  <input type="radio" name="delivery_method" value="home_delivery" required>
+                  <span>Dostawa do domu</span>
+                </label>
+              </fieldset>
+              <label class="cart-details-form__field" data-delivery-address-field hidden>
+                <span>Adres dostawy *</span>
+                <textarea name="delivery_address" rows="3" placeholder="Ulica i numer&#10;Kod pocztowy i miasto"></textarea>
+              </label>
+              <label class="cart-details-form__field" data-pickup-point-field hidden>
+                <span>Paczkomat / punkt odbioru *</span>
+                <textarea name="pickup_point" rows="2" placeholder="np. Kod lub adres punktu odbioru"></textarea>
+              </label>
               <label class="cart-details-form__field">
                 <span>Wiadomość (opcjonalne)</span>
                 <textarea name="message" rows="4"></textarea>
+              </label>
+              <label class="cart-details-form__checkbox">
+                <input type="checkbox" name="gdprConsent" required>
+                <span>Wyrażam zgodę na przetwarzanie moich danych osobowych w celu obsługi zapytania i realizacji kontaktu zwrotnego. *</span>
               </label>
               <p class="cart-details-form__required-note">* - pola wymagane</p>
               <p class="cart-details-form__status" data-cart-form-status aria-live="polite"></p>

--- a/sklep/index.html
+++ b/sklep/index.html
@@ -124,9 +124,24 @@
                 <span>Telefon *</span>
                 <input type="tel" name="customerPhone" required autocomplete="tel">
               </label>
-              <label class="cart-details-form__field">
-                <span>Adres dostawy / kod paczkomatu *</span>
-                <textarea name="delivery_address" rows="3" required placeholder="Wpisz adres dostawy albo kod paczkomatu / punktu odbioru"></textarea>
+              <fieldset class="cart-details-form__fieldset" data-delivery-method-fieldset>
+                <legend>Sposób dostawy *</legend>
+                <label class="cart-details-form__radio">
+                  <input type="radio" name="delivery_method" value="pickup_point" required>
+                  <span>Paczkomat / punkt odbioru</span>
+                </label>
+                <label class="cart-details-form__radio">
+                  <input type="radio" name="delivery_method" value="home_delivery" required>
+                  <span>Dostawa do domu</span>
+                </label>
+              </fieldset>
+              <label class="cart-details-form__field" data-delivery-address-field hidden>
+                <span>Adres dostawy *</span>
+                <textarea name="delivery_address" rows="3" placeholder="Ulica i numer&#10;Kod pocztowy i miasto"></textarea>
+              </label>
+              <label class="cart-details-form__field" data-pickup-point-field hidden>
+                <span>Paczkomat / punkt odbioru *</span>
+                <textarea name="pickup_point" rows="2" placeholder="np. Kod lub adres punktu odbioru"></textarea>
               </label>
               <label class="cart-details-form__field">
                 <span>Wiadomość (opcjonalne)</span>

--- a/sklep/kalendarz-2026.html
+++ b/sklep/kalendarz-2026.html
@@ -156,9 +156,24 @@
                 <span>Telefon *</span>
                 <input type="tel" name="customerPhone" required autocomplete="tel">
               </label>
-              <label class="cart-details-form__field">
-                <span>Adres dostawy / kod paczkomatu *</span>
-                <textarea name="delivery_address" rows="3" required placeholder="Wpisz adres dostawy albo kod paczkomatu / punktu odbioru"></textarea>
+              <fieldset class="cart-details-form__fieldset" data-delivery-method-fieldset>
+                <legend>Sposób dostawy *</legend>
+                <label class="cart-details-form__radio">
+                  <input type="radio" name="delivery_method" value="pickup_point" required>
+                  <span>Paczkomat / punkt odbioru</span>
+                </label>
+                <label class="cart-details-form__radio">
+                  <input type="radio" name="delivery_method" value="home_delivery" required>
+                  <span>Dostawa do domu</span>
+                </label>
+              </fieldset>
+              <label class="cart-details-form__field" data-delivery-address-field hidden>
+                <span>Adres dostawy *</span>
+                <textarea name="delivery_address" rows="3" placeholder="Ulica i numer&#10;Kod pocztowy i miasto"></textarea>
+              </label>
+              <label class="cart-details-form__field" data-pickup-point-field hidden>
+                <span>Paczkomat / punkt odbioru *</span>
+                <textarea name="pickup_point" rows="2" placeholder="np. Kod lub adres punktu odbioru"></textarea>
               </label>
               <label class="cart-details-form__field">
                 <span>Wiadomość (opcjonalne)</span>

--- a/sklep/t-shirt-damski-classic.html
+++ b/sklep/t-shirt-damski-classic.html
@@ -166,9 +166,32 @@
                 <span>Telefon *</span>
                 <input type="tel" name="customerPhone" required autocomplete="tel">
               </label>
+              <fieldset class="cart-details-form__fieldset" data-delivery-method-fieldset>
+                <legend>Sposób dostawy *</legend>
+                <label class="cart-details-form__radio">
+                  <input type="radio" name="delivery_method" value="pickup_point" required>
+                  <span>Paczkomat / punkt odbioru</span>
+                </label>
+                <label class="cart-details-form__radio">
+                  <input type="radio" name="delivery_method" value="home_delivery" required>
+                  <span>Dostawa do domu</span>
+                </label>
+              </fieldset>
+              <label class="cart-details-form__field" data-delivery-address-field hidden>
+                <span>Adres dostawy *</span>
+                <textarea name="delivery_address" rows="3" placeholder="Ulica i numer&#10;Kod pocztowy i miasto"></textarea>
+              </label>
+              <label class="cart-details-form__field" data-pickup-point-field hidden>
+                <span>Paczkomat / punkt odbioru *</span>
+                <textarea name="pickup_point" rows="2" placeholder="np. Kod lub adres punktu odbioru"></textarea>
+              </label>
               <label class="cart-details-form__field">
                 <span>Wiadomość (opcjonalne)</span>
                 <textarea name="message" rows="4"></textarea>
+              </label>
+              <label class="cart-details-form__checkbox">
+                <input type="checkbox" name="gdprConsent" required>
+                <span>Wyrażam zgodę na przetwarzanie moich danych osobowych w celu obsługi zapytania i realizacji kontaktu zwrotnego. *</span>
               </label>
               <p class="cart-details-form__required-note">* - pola wymagane</p>
               <p class="cart-details-form__status" data-cart-form-status aria-live="polite"></p>

--- a/sklep/t-shirt-meski-classic.html
+++ b/sklep/t-shirt-meski-classic.html
@@ -166,9 +166,32 @@
                 <span>Telefon *</span>
                 <input type="tel" name="customerPhone" required autocomplete="tel">
               </label>
+              <fieldset class="cart-details-form__fieldset" data-delivery-method-fieldset>
+                <legend>Sposób dostawy *</legend>
+                <label class="cart-details-form__radio">
+                  <input type="radio" name="delivery_method" value="pickup_point" required>
+                  <span>Paczkomat / punkt odbioru</span>
+                </label>
+                <label class="cart-details-form__radio">
+                  <input type="radio" name="delivery_method" value="home_delivery" required>
+                  <span>Dostawa do domu</span>
+                </label>
+              </fieldset>
+              <label class="cart-details-form__field" data-delivery-address-field hidden>
+                <span>Adres dostawy *</span>
+                <textarea name="delivery_address" rows="3" placeholder="Ulica i numer&#10;Kod pocztowy i miasto"></textarea>
+              </label>
+              <label class="cart-details-form__field" data-pickup-point-field hidden>
+                <span>Paczkomat / punkt odbioru *</span>
+                <textarea name="pickup_point" rows="2" placeholder="np. Kod lub adres punktu odbioru"></textarea>
+              </label>
               <label class="cart-details-form__field">
                 <span>Wiadomość (opcjonalne)</span>
                 <textarea name="message" rows="4"></textarea>
+              </label>
+              <label class="cart-details-form__checkbox">
+                <input type="checkbox" name="gdprConsent" required>
+                <span>Wyrażam zgodę na przetwarzanie moich danych osobowych w celu obsługi zapytania i realizacji kontaktu zwrotnego. *</span>
               </label>
               <p class="cart-details-form__required-note">* - pola wymagane</p>
               <p class="cart-details-form__status" data-cart-form-status aria-live="polite"></p>

--- a/style.css
+++ b/style.css
@@ -3508,6 +3508,33 @@
   resize: vertical;
 }
 
+.cart-details-form__fieldset {
+  display: grid;
+  gap: 9px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.cart-details-form__fieldset legend {
+  margin: 0 0 2px;
+  padding: 0;
+  color: #f3f5f7;
+  font-weight: 600;
+}
+
+.cart-details-form__radio {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  color: #f3f5f7;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.cart-details-form__radio input[type="radio"] {
+  margin-top: 2px;
+}
 
 .cart-details-form__checkbox {
   display: flex;


### PR DESCRIPTION
### Motivation
- Zastąpić jedno pole „Adres dostawy / kod paczkomatu” jasnym wyborem sposobu dostawy i dwoma oddzielnymi polami, aby poprawić walidację i wysyłkę danych.
- Umożliwić wysyłanie do Google Sheets tylko `delivery_address` i `pickup_point`, a do EmailJS dodatkowo `delivery_method`, bez zmiany wyglądu formularza i istniejącej logiki modalnej.

### Description
- Zaktualizowano szablony `sklep/*.html` aby zastąpić poprzednie pole jednym fieldsetem radiowym `delivery_method` oraz dwiema warunkowymi etykietami pól z atrybutami `data-delivery-address-field` i `data-pickup-point-field` zawierającymi `name="delivery_address"` i `name="pickup_point"`.
- Dodano do `shop.js` funkcje `updateDeliveryFields(form)` i `setupDeliveryFields(form)` oraz zintegrowano je w uruchamianiu modala i przed wysłaniem formularza, aby dynamicznie pokazywać/ukrywać pola i ustawiać `required` zgodnie z wybraną metodą dostawy.
- Rozszerzono walidację przed submitem tak, że wybór `delivery_method` jest wymagany, `delivery_address` jest wymagane tylko przy `home_delivery`, a `pickup_point` tylko przy `pickup_point`, przy czym zgoda RODO (`gdprConsent`) pozostała wymagana.
- Zmodyfikowano payload wysyłany do Google Sheets tak, by zawierał `delivery_address` i `pickup_point` (bez `delivery_method`), a do EmailJS dodano pola `delivery_method`, `delivery_address` i `pickup_point` poprzez uaktualnienie `sendOrderEmail` (pozostałe pola wysyłane jak wcześniej pozostają bez zmian).
- Dodano niewielkie zmiany w `style.css` (`.cart-details-form__fieldset`, `.cart-details-form__radio`) aby nowe kontrolki radiowe zachowały dotychczasowy wygląd formularza i responsywność.

### Testing
- Uruchomiono `node --check shop.js` i sprawdzenie przeszło bez błędów (poprawna składnia JS).
- Wykonano skrypt `python3` sprawdzający obecność pól `delivery_method`, `delivery_address`, `pickup_point` i `gdprConsent` we wszystkich `sklep/*.html`, test zakończył się pozytywnie.
- Uruchomiono `git diff --check` / sprawdzenia statyczne i nie zgłosiły problemów.
- Próba wygenerowania zrzutu ekranu przez Playwright (`npx playwright screenshot`) nie powiodła się, ponieważ środowisko nie mogło pobrać binarek przeglądarki (błąd CDN 403), więc interakcyjny screenshot/runtimowy test UI nie został wykonany.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a291306bdec83308735d17bc4dd975b)