### PR TITLE
Fix delivery fields visibility and mobile cart scrolling

### DIFF
--- a/style.css
+++ b/style.css
@@ -3305,6 +3305,7 @@
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(6px);
   padding: 20px;
+  overflow-y: auto;
   opacity: 0;
   pointer-events: none;
   transition: opacity 180ms ease;
@@ -3324,7 +3325,7 @@
 .shop-modal__panel {
   position: relative;
   width: min(960px, 100%);
-  max-height: 90vh;
+  max-height: min(90vh, calc(100dvh - 40px));
   overflow: auto;
   background: rgba(8, 10, 12, 0.95);
   border: 1px solid rgba(255, 255, 255, 0.08);
@@ -3488,6 +3489,10 @@
   gap: 6px;
 }
 
+.cart-details-form__field[hidden] {
+  display: none !important;
+}
+
 .cart-details-form__field span {
   color: #f3f5f7;
   font-weight: 600;
@@ -3636,8 +3641,13 @@ body.is-modal-open {
     align-items: flex-start;
   }
 
+  .shop-modal {
+    align-items: start;
+    padding-block: 12px;
+  }
+
   .shop-modal__panel {
-    max-height: none;
+    max-height: calc(100dvh - 24px);
     height: auto;
   }
 }
@@ -3655,6 +3665,10 @@ body.is-modal-open {
   .cart-list,
   .shop-item {
     border-radius: 14px;
+  }
+
+  .shop-modal {
+    padding-inline: 10px;
   }
 
   .shop-modal__panel {


### PR DESCRIPTION
### Motivation
- Ensure the delivery detail fields are truly hidden when not relevant so "Adres dostawy *" only appears for `Dostawa do domu` and "Paczkomat / punkt odbioru *" only for `Paczkomat / punkt odbioru`.
- Make the cart/details modal usable on phones by allowing vertical scrolling and constraining the panel height to the viewport.
- Prevent CSS layout rules from overriding the JS-driven hiding of delivery fields.

### Description
- Updated `style.css` to make `.shop-modal` vertically scrollable by adding `overflow-y: auto;` and to constrain the panel height with `max-height: min(90vh, calc(100dvh - 40px));`.
- Added `.cart-details-form__field[hidden] { display: none !important; }` to ensure fields marked `hidden` are actually removed from layout despite grid/form styles.
- Adjusted responsive modal behavior for smaller screens by aligning the modal to the top and tweaking `padding-block`, `padding-inline` and `max-height` to use `100dvh`-based calculations so the panel fits and scrolls on mobile.
- Left `shop.js` unchanged because `updateDeliveryFields` already toggles `hidden` and `required` on delivery inputs and handles validation.

### Testing
- Ran `git diff --check` to ensure there are no whitespace or diff-check issues and it succeeded.
- Executed a static Python verification that asserts the presence of the new CSS rules in `style.css` and that shop HTML files contain `data-delivery-address-field hidden` and `data-pickup-point-field hidden`, and the script succeeded.
- Attempted to capture a mobile screenshot with Playwright for visual verification, but the Playwright Chromium download failed with a CDN `403 Domain forbidden` error so the screenshot step did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2917b3c1f08330871e41324d258190)